### PR TITLE
feat: navigate to course component from course dates tab

### DIFF
--- a/Course/Course/Presentation/CourseRouter.swift
+++ b/Course/Course/Presentation/CourseRouter.swift
@@ -59,6 +59,8 @@ public protocol CourseRouter: BaseRouter {
         router: Course.CourseRouter,
         cssInjector: CSSInjector
     )
+    
+    func showCourseComponent(componentID: String, courseStructure: CourseStructure)
 }
 
 // Mark - For testing and SwiftUI preview
@@ -117,5 +119,9 @@ public class CourseRouterMock: BaseRouterMock, CourseRouter {
         cssInjector: CSSInjector
     ) {}
     
+    public func showCourseComponent(
+        componentID: String,
+        courseStructure: CourseStructure
+    ) {}
 }
 #endif

--- a/Course/Course/Presentation/Dates/CourseDatesView.swift
+++ b/Course/Course/Presentation/Dates/CourseDatesView.swift
@@ -142,7 +142,8 @@ struct CourseDateListView: View {
                                          lastDate: viewModel.sortedDates.last,
                                          allHaveSameStatus: allHaveSameStatus)
                             
-                            BlockStatusView(block: block,
+                            BlockStatusView(viewModel: viewModel, 
+                                            block: block,
                                             allHaveSameStatus: allHaveSameStatus,
                                             blocks: blocks)
                                             
@@ -158,6 +159,7 @@ struct CourseDateListView: View {
 }
 
 struct BlockStatusView: View {
+    let viewModel: CourseDatesViewModel
     let block: CourseDateBlock
     let allHaveSameStatus: Bool
     let blocks: [CourseDateBlock]
@@ -226,7 +228,9 @@ struct BlockStatusView: View {
                 }
             }())
             .onTapGesture {
-                
+                Task {
+                    await viewModel.showCourseDetails(componentID: block.firstComponentBlockID)
+                }
             }
     }
     

--- a/Course/Course/Presentation/Dates/CourseDatesViewModel.swift
+++ b/Course/Course/Presentation/Dates/CourseDatesViewModel.swift
@@ -27,6 +27,7 @@ public class CourseDatesViewModel: ObservableObject {
     let cssInjector: CSSInjector
     let router: CourseRouter
     let connectivity: ConnectivityProtocol
+    let courseID: String
     
     public init(
         interactor: CourseInteractorProtocol,
@@ -39,6 +40,7 @@ public class CourseDatesViewModel: ObservableObject {
         self.router = router
         self.cssInjector = cssInjector
         self.connectivity = connectivity
+        self.courseID = courseID
     }
         
     var sortedDates: [Date] {
@@ -67,6 +69,18 @@ public class CourseDatesViewModel: ObservableObject {
             } else {
                 errorMessage = CoreLocalization.Error.unknownError
             }
+        }
+    }
+    
+    func showCourseDetails(componentID: String) async {
+        do {
+            let courseStructure = try await interactor.getCourseBlocks(courseID: courseID)
+            router.showCourseComponent(
+                componentID: componentID,
+                courseStructure: courseStructure
+            )
+        } catch let error {
+            print(error)
         }
     }
 }

--- a/OpenEdX/Router.swift
+++ b/OpenEdX/Router.swift
@@ -284,6 +284,34 @@ public class Router: AuthorizationRouter,
         navigationController.pushViewController(controller, animated: true)
     }
     
+    public func showCourseComponent(
+        componentID: String,
+        courseStructure: CourseStructure) {
+            courseStructure.childs.enumerated().forEach { chapterIndex, chapter in
+                chapter.childs.enumerated().forEach { sequentialIndex, sequential in
+                    sequential.childs.enumerated().forEach { verticalIndex, vertical in
+                        vertical.childs.forEach { block in
+                            if block.id == componentID {
+                                DispatchQueue.main.async { [weak self] in
+                                    guard let self = self else { return }
+                                    self.showCourseUnit(courseName: courseStructure.displayName,
+                                                        blockId: block.blockId,
+                                                        courseID: courseStructure.id,
+                                                        sectionName: sequential.displayName,
+                                                        verticalIndex: verticalIndex,
+                                                        chapters: courseStructure.childs,
+                                                        chapterIndex: chapterIndex,
+                                                        sequentialIndex: sequentialIndex)
+                                    return
+                                }
+                                
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    
     public func replaceCourseUnit(
         courseName: String,
         blockId: String,


### PR DESCRIPTION
This PR adds support for navigating to First Component ID, which is available from a Block inside Course Dates, to Course Unit screen.


https://github.com/openedx/openedx-app-ios/assets/960241/7c190627-4eeb-410b-9b49-7c7bf04fe3ea

