### PR TITLE
feat: navigate to course component from course dates tab

### DIFF
--- a/Course/Course/Data/CourseRepository.swift
+++ b/Course/Course/Data/CourseRepository.swift
@@ -11,8 +11,8 @@ import Core
 public protocol CourseRepositoryProtocol {
     func getCourseDetails(courseID: String) async throws -> CourseDetails
     func getCourseBlocks(courseID: String) async throws -> CourseStructure
-    func getCourseDetailsOffline(courseID: String) async throws -> CourseDetails
-    func getCourseBlocksOffline(courseID: String) throws -> CourseStructure
+    func getLoadedCourseDetails(courseID: String) async throws -> CourseDetails
+    func getLoadedCourseBlocks(courseID: String) throws -> CourseStructure
     func enrollToCourse(courseID: String) async throws -> Bool
     func blockCompletionRequest(courseID: String, blockID: String) async throws
     func getHandouts(courseID: String) async throws -> String?
@@ -48,7 +48,7 @@ public class CourseRepository: CourseRepositoryProtocol {
         return response
     }
     
-    public func getCourseDetailsOffline(courseID: String) async throws -> CourseDetails {
+    public func getLoadedCourseDetails(courseID: String) async throws -> CourseDetails {
         return try persistence.loadCourseDetails(courseID: courseID)
     }
         
@@ -61,7 +61,7 @@ public class CourseRepository: CourseRepositoryProtocol {
         return parsedStructure
     }
     
-    public func getCourseBlocksOffline(courseID: String) throws -> CourseStructure {
+    public func getLoadedCourseBlocks(courseID: String) throws -> CourseStructure {
         let localData = try persistence.loadCourseStructure(courseID: courseID)
         return parseCourseStructure(course: localData)
     }
@@ -259,7 +259,7 @@ class CourseRepositoryMock: CourseRepositoryProtocol {
         }
     }
     
-    func getCourseDetailsOffline(courseID: String) async throws -> CourseDetails {
+    func getLoadedCourseDetails(courseID: String) async throws -> CourseDetails {
         return CourseDetails(
             courseID: "courseID",
             org: "Organization",
@@ -276,7 +276,7 @@ class CourseRepositoryMock: CourseRepositoryProtocol {
         )
     }
     
-    func getCourseBlocksOffline(courseID: String) throws -> CourseStructure {
+    func getLoadedCourseBlocks(courseID: String) throws -> CourseStructure {
         let decoder = JSONDecoder()
         let jsonData = Data(courseStructureJson.utf8)
         let courseBlocks = try decoder.decode(DataLayer.CourseStructure.self, from: jsonData)

--- a/Course/Course/Domain/CourseInteractor.swift
+++ b/Course/Course/Domain/CourseInteractor.swift
@@ -63,11 +63,11 @@ public class CourseInteractor: CourseInteractorProtocol {
     }
     
     public func getCourseDetailsOffline(courseID: String) async throws -> CourseDetails {
-        return try await repository.getCourseDetailsOffline(courseID: courseID)
+        return try await repository.getLoadedCourseDetails(courseID: courseID)
     }
     
     public func getCourseBlocksOffline(courseID: String) async throws -> CourseStructure {
-        return try repository.getCourseBlocksOffline(courseID: courseID)
+        return try repository.getLoadedCourseBlocks(courseID: courseID)
     }
     
     public func enrollToCourse(courseID: String) async throws -> Bool {

--- a/Course/Course/Presentation/CourseRouter.swift
+++ b/Course/Course/Presentation/CourseRouter.swift
@@ -59,6 +59,11 @@ public protocol CourseRouter: BaseRouter {
         router: Course.CourseRouter,
         cssInjector: CSSInjector
     )
+    
+    func showCourseComponent(
+        componentID: String,
+        courseStructure: CourseStructure
+    )
 }
 
 // Mark - For testing and SwiftUI preview
@@ -115,6 +120,11 @@ public class CourseRouterMock: BaseRouterMock, CourseRouter {
         announcements: [CourseUpdate]?,
         router: Course.CourseRouter,
         cssInjector: CSSInjector
+    ) {}
+    
+    public func showCourseComponent(
+        componentID: String,
+        courseStructure: CourseStructure
     ) {}
     
 }

--- a/Course/Course/Presentation/Dates/CourseDatesView.swift
+++ b/Course/Course/Presentation/Dates/CourseDatesView.swift
@@ -143,7 +143,8 @@ struct CourseDateListView: View {
                                          lastDate: viewModel.sortedDates.last,
                                          allHaveSameStatus: allHaveSameStatus)
                             
-                            BlockStatusView(block: block,
+                            BlockStatusView(viewModel: viewModel,
+                                            block: block,
                                             allHaveSameStatus: allHaveSameStatus,
                                             blocks: blocks)
                                             
@@ -159,6 +160,7 @@ struct CourseDateListView: View {
 }
 
 struct BlockStatusView: View {
+    let viewModel: CourseDatesViewModel
     let block: CourseDateBlock
     let allHaveSameStatus: Bool
     let blocks: [CourseDateBlock]
@@ -227,7 +229,9 @@ struct BlockStatusView: View {
                 }
             }())
             .onTapGesture {
-                
+                Task {
+                    await viewModel.showCourseDetails(componentID: block.firstComponentBlockID)
+                }
             }
     }
     

--- a/Course/Course/Presentation/Dates/CourseDatesViewModel.swift
+++ b/Course/Course/Presentation/Dates/CourseDatesViewModel.swift
@@ -27,6 +27,7 @@ public class CourseDatesViewModel: ObservableObject {
     let cssInjector: CSSInjector
     let router: CourseRouter
     let connectivity: ConnectivityProtocol
+    let courseID: String
     
     public init(
         interactor: CourseInteractorProtocol,
@@ -39,6 +40,7 @@ public class CourseDatesViewModel: ObservableObject {
         self.router = router
         self.cssInjector = cssInjector
         self.connectivity = connectivity
+        self.courseID = courseID
     }
         
     var sortedDates: [Date] {
@@ -69,4 +71,16 @@ public class CourseDatesViewModel: ObservableObject {
             }
         }
     }
+    
+    func showCourseDetails(componentID: String) async {
+            do {
+                let courseStructure = try await interactor.getCourseBlocks(courseID: courseID)
+                router.showCourseComponent(
+                    componentID: componentID,
+                    courseStructure: courseStructure
+                )
+            } catch let error {
+                print(error)
+            }
+        }
 }

--- a/OpenEdX/Router.swift
+++ b/OpenEdX/Router.swift
@@ -307,6 +307,33 @@ public class Router: AuthorizationRouter,
         navigationController.pushViewController(controller, animated: true)
     }
     
+    public func showCourseComponent(
+        componentID: String,
+        courseStructure: CourseStructure) {
+            courseStructure.childs.enumerated().forEach { chapterIndex, chapter in
+                chapter.childs.enumerated().forEach { sequentialIndex, sequential in
+                    sequential.childs.enumerated().forEach { verticalIndex, vertical in
+                        vertical.childs.forEach { block in
+                            if block.id == componentID {
+                                DispatchQueue.main.async { [weak self] in
+                                    guard let self = self else { return }
+                                    self.showCourseUnit(courseName: courseStructure.displayName,
+                                                        blockId: block.blockId,
+                                                        courseID: courseStructure.id,
+                                                        sectionName: sequential.displayName,
+                                                        verticalIndex: verticalIndex,
+                                                        chapters: courseStructure.childs,
+                                                        chapterIndex: chapterIndex,
+                                                        sequentialIndex: sequentialIndex)
+                                    return
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    
     public func replaceCourseUnit(
         courseName: String,
         blockId: String,


### PR DESCRIPTION
This PR adds support for navigating to the First Component ID, which is available from a block inside Course Dates, to the Course Unit screen.


https://github.com/openedx/openedx-app-ios/assets/5606473/baf1cd75-26c8-4dba-9b6b-ebed8168ebe9

**Note:** I didn't have write permissions on Umer's fork, so I'm taking over the PR and creating a new PR from the existing PR (https://github.com/openedx/openedx-app-ios/pull/185).
In the new PR, I've created it on the latest develop branch and fixed the case where on every hyperlink click blocks API was being hit.