### PR TITLE
arrow animation & fix for section title

### DIFF
--- a/Course/Course/Presentation/Outline/CourseExpandableContentView.swift
+++ b/Course/Course/Presentation/Outline/CourseExpandableContentView.swift
@@ -50,14 +50,9 @@ struct CourseExpandableContentView: View {
                 .lineLimit(1)
                 .foregroundColor(Theme.Colors.textPrimary)
             Spacer()
-            if isExpanded {
-                Image(systemName: "chevron.right")
-                    .foregroundColor(Theme.Colors.accentColor)
-                    .rotationEffect(.degrees(90))
-            } else {
-                Image(systemName: "chevron.right")
-                    .foregroundColor(Theme.Colors.accentColor)
-            }
+            Image(systemName: "chevron.right")
+                .foregroundColor(Theme.Colors.accentColor)
+                .dropdownArrowRotationAnimation(value: isExpanded)
         }
         .padding(.horizontal, 30)
         .padding(.vertical, 15)

--- a/Course/Course/Presentation/Unit/CourseUnitView.swift
+++ b/Course/Course/Presentation/Unit/CourseUnitView.swift
@@ -296,21 +296,26 @@ public struct CourseUnitView: View {
                             }
                         }
                         VStack {
-                            NavigationBar(
-                                title: isDropdownActive ? sequenceTitle : "",
-                                leftButtonAction: {
-                                    viewModel.router.back()
-                                    playerStateSubject.send(VideoPlayerState.kill)
-                                }).padding(.top, isHorizontal ? 10 : 0)
+                            Group {
+                                NavigationBar(
+                                    title: isDropdownActive ? sequenceTitle : "",
+                                    leftButtonAction: {
+                                        viewModel.router.back()
+                                        playerStateSubject.send(VideoPlayerState.kill)
+                                    })
+                                .padding(.top, isHorizontal ? 10 : 0)
                                 .padding(.leading, isHorizontal ? -16 : 0)
-                            if isDropdownActive {
-                                CourseUnitDropDownTitle(
-                                    title: unitTitle,
-                                    isAvailable: isDropdownAvailable,
-                                    showDropdown: $showDropdown)
-                                .padding(.top, 0)
-                                .offset(y: -25)
+                                if isDropdownActive {
+                                    CourseUnitDropDownTitle(
+                                        title: unitTitle,
+                                        isAvailable: isDropdownAvailable,
+                                        showDropdown: $showDropdown)
+                                    .padding(.top, 0)
+                                    .padding(.horizontal, 48)
+                                    .offset(y: -25)
+                                }
                             }
+                            .padding(.trailing, isHorizontal ? 215 : 0)
                             Spacer()
                         }
                         HStack(alignment: .center) {

--- a/Course/Course/Presentation/Unit/Subviews/DropdownList/CourseUnitDropDownTitle.swift
+++ b/Course/Course/Presentation/Unit/Subviews/DropdownList/CourseUnitDropDownTitle.swift
@@ -22,19 +22,17 @@ struct CourseUnitDropDownTitle: View {
                 HStack {
                     Text(title)
                         .opacity(showDropdown ? 0.7 : 1.0)
+                        .lineLimit(1)
                     if isAvailable {
-                        if showDropdown {
-                            Image(systemName: "chevron.right")
-                                .rotationEffect(.degrees(90))
-                        } else {
-                            Image(systemName: "chevron.right")
-                        }
+                        Image(systemName: "chevron.right")
+                            .dropdownArrowRotationAnimation(value: showDropdown)
                     }
                 }
             }
             .buttonStyle(.plain)
         } else {
             Text(title)
+                .lineLimit(1)
         }
     }
 }

--- a/Course/Course/Presentation/Unit/Subviews/DropdownList/CourseUnitVerticalsDropdownView.swift
+++ b/Course/Course/Presentation/Unit/Subviews/DropdownList/CourseUnitVerticalsDropdownView.swift
@@ -31,6 +31,10 @@ struct CourseUnitVerticalsDropdownView: View {
                         isLast: isLast,
                         isSelected: isSelected
                     ) {
+                        if isSelected {
+                            showDropdown.toggle()
+                            return
+                        }
                         action(vertical)
                     }
                 }

--- a/Course/Course/Presentation/Unit/Subviews/DropdownList/CourseUnitVerticalsDropdownView.swift
+++ b/Course/Course/Presentation/Unit/Subviews/DropdownList/CourseUnitVerticalsDropdownView.swift
@@ -22,6 +22,12 @@ struct CourseUnitVerticalsDropdownView: View {
                 .onTapGesture {
                     showDropdown.toggle()
                 }
+                .simultaneousGesture(
+                    DragGesture()
+                        .onChanged { _ in
+                            if showDropdown { showDropdown.toggle() }
+                        }
+                )
             CourseUnitDropDownList(content: {
                 ForEach(verticals, id: \.id) { vertical in
                     let isLast = verticals.last?.id == vertical.id

--- a/Course/Course/Presentation/Unit/Subviews/DropdownList/DropdownAnimationModifier.swift
+++ b/Course/Course/Presentation/Unit/Subviews/DropdownList/DropdownAnimationModifier.swift
@@ -20,8 +20,21 @@ struct DropdownAnimationModifier<V>: ViewModifier where V: Equatable {
     }
 }
 
+struct DropdownArrowRotationModifier: ViewModifier {
+    var value: Bool
+    func body(content: Content) -> some View {
+        content
+            .rotationEffect(value ? .degrees(90) : .degrees(0))
+            .animation(.easeOut(duration: 0.2), value: value)
+    }
+}
+
 extension View {
     func dropdownAnimation<V>(isActive: Bool, value: V) -> some View where V: Equatable {
         modifier(DropdownAnimationModifier(isActive: isActive, value: value))
+    }
+
+    func dropdownArrowRotationAnimation(value: Bool) -> some View {
+        modifier(DropdownArrowRotationModifier(value: value))
     }
 }


### PR DESCRIPTION
### That PR contains two tickets:

* [iOS] Fix section title displayed in two lines #208
* [iOS] Improve arrow animation for section drop-down and sequence nested lists #207
* [iOS] Long section name is partially overlapped by navigation buttons #205
* [iOS] Content page reloads when it is reselected in the drop-down list #204

### Previews:

#### [iOS] Fix section title displayed in two lines #208 & [iOS] Long section name is partially overlapped by navigation buttons #205

[![_Simulator Screenshot - iPhone 15 - 2023-12-14 at 16 19 10](https://github.com/touchapp/openedx-app-ios/assets/480059/3a0ebbd0-f1a8-4f33-9615-0618ec54cb7e)](https://github.com/touchapp/openedx-app-ios/assets/480059/9ad9d15f-6b48-4c78-ab81-aa5900ec80cd)
[![_Simulator Screenshot - iPhone 15 - 2023-12-14 at 16 19 12](https://github.com/touchapp/openedx-app-ios/assets/480059/7bcf237e-567b-4e51-92cc-e7a9c426dafd)](https://github.com/touchapp/openedx-app-ios/assets/480059/4e8c4bbf-0fc4-4ccd-87b6-18a8a48f8544)
[![_Simulator Screenshot - iPhone 15 - 2023-12-14 at 16 20 54](https://github.com/touchapp/openedx-app-ios/assets/480059/9c2ce872-14b7-4b4c-a519-ebf8e477559e)](https://github.com/touchapp/openedx-app-ios/assets/480059/4e918e2d-efd6-4d4b-b296-0dab17862c28)
[![_Simulator Screenshot - iPhone 15 - 2023-12-14 at 16 20 56](https://github.com/touchapp/openedx-app-ios/assets/480059/592ba272-1cd2-4e24-ac4d-8c3305817a74)](https://github.com/touchapp/openedx-app-ios/assets/480059/96069fd9-43a0-450a-b245-e73c8fc33619)

#### [iOS] Improve arrow animation for section drop-down and sequence nested lists #207
https://github.com/touchapp/openedx-app-ios/assets/480059/39303609-7454-4e97-8f16-7c6e1ada994b

https://github.com/touchapp/openedx-app-ios/assets/480059/e59a1bf7-1d43-4a5f-ad4f-307d19ba7c61

