### PR TITLE
feat: Update course resume logic, navigate learner to last viewed component

### DIFF
--- a/Core/Core/SwiftGen/Strings.swift
+++ b/Core/Core/SwiftGen/Strings.swift
@@ -31,8 +31,6 @@ public enum CoreLocalization {
     public static let backToOutline = CoreLocalization.tr("Localizable", "COURSEWARE.BACK_TO_OUTLINE", fallback: "Back to outline")
     /// Continue
     public static let `continue` = CoreLocalization.tr("Localizable", "COURSEWARE.CONTINUE", fallback: "Continue")
-    /// Continue with:
-    public static let continueWith = CoreLocalization.tr("Localizable", "COURSEWARE.CONTINUE_WITH", fallback: "Continue with:")
     /// Course content
     public static let courseContent = CoreLocalization.tr("Localizable", "COURSEWARE.COURSE_CONTENT", fallback: "Course content")
     /// Course units
@@ -55,6 +53,8 @@ public enum CoreLocalization {
     public static let previous = CoreLocalization.tr("Localizable", "COURSEWARE.PREVIOUS", fallback: "Prev")
     /// Resume
     public static let resume = CoreLocalization.tr("Localizable", "COURSEWARE.RESUME", fallback: "Resume")
+    /// Resume with:
+    public static let resumeWith = CoreLocalization.tr("Localizable", "COURSEWARE.RESUME_WITH", fallback: "Resume with:")
     /// Section “
     public static let section = CoreLocalization.tr("Localizable", "COURSEWARE.SECTION", fallback: "Section “")
   }

--- a/Core/Core/en.lproj/Localizable.strings
+++ b/Core/Core/en.lproj/Localizable.strings
@@ -33,7 +33,7 @@
 "COURSEWARE.IS_FINISHED" = "“ is finished.";
 "COURSEWARE.CONTINUE" = "Continue";
 "COURSEWARE.RESUME" = "Resume";
-"COURSEWARE.CONTINUE_WITH" = "Continue with:";
+"COURSEWARE.RESUME_WITH" = "Resume with:";
 "COURSEWARE.NEXT_SECTION" = "Next section";
 
 "COURSEWARE.NEXT_SECTION_DESCRIPTION_FIRST" = "To proceed with “";

--- a/Core/Core/uk.lproj/Localizable.strings
+++ b/Core/Core/uk.lproj/Localizable.strings
@@ -32,7 +32,7 @@
 "COURSEWARE.IS_FINISHED" = "“ завершена.";
 "COURSEWARE.CONTINUE" = "Продовжити";
 "COURSEWARE.RESUME" = "Resume";
-"COURSEWARE.CONTINUE_WITH" = "Продовжити далі:";
+"COURSEWARE.RESUME_WITH" = "Продовжити далі:";
 "COURSEWARE.NEXT_SECTION" = "Наступний розділ";
 
 "COURSEWARE.NEXT_SECTION_DESCRIPTION_FIRST" = "Щоб перейти до “";

--- a/Course/Course/Presentation/Container/CourseContainerViewModel.swift
+++ b/Course/Course/Presentation/Container/CourseContainerViewModel.swift
@@ -277,7 +277,8 @@ public class CourseContainerViewModel: BaseCourseViewModel {
                         return ContinueWith(
                             chapterIndex: chapterIndex,
                             sequentialIndex: sequentialIndex,
-                            verticalIndex: verticalIndex
+                            verticalIndex: verticalIndex,
+                            lastVisitedBlockId: block.id
                         )
                     }
                 }

--- a/Course/Course/Presentation/Outline/ContinueWithView.swift
+++ b/Course/Course/Presentation/Outline/ContinueWithView.swift
@@ -13,29 +13,28 @@ struct ContinueWith {
     let chapterIndex: Int
     let sequentialIndex: Int
     let verticalIndex: Int
+    let lastVisitedBlockId: String
 }
 
 struct ContinueWithView: View {
     private let data: ContinueWith
-    private let courseStructure: CourseStructure
     private let action: () -> Void
+    private let courseContinueUnit: CourseVertical
     
     private var idiom: UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }
     
-    init(data: ContinueWith, courseStructure: CourseStructure, action: @escaping () -> Void) {
+    init(data: ContinueWith, courseContinueUnit: CourseVertical, action: @escaping () -> Void) {
         self.data = data
-        self.courseStructure = courseStructure
         self.action = action
+        self.courseContinueUnit = courseContinueUnit
     }
     
     var body: some View {
         VStack(alignment: .leading) {
-            let chapter = courseStructure.childs[data.chapterIndex]
-            if let vertical = chapter.childs[data.sequentialIndex].childs.first {
                 if idiom == .pad {
                     HStack(alignment: .top) {
                         VStack(alignment: .leading) {
-                            ContinueTitle(vertical: vertical)
+                            ContinueTitle(vertical: courseContinueUnit)
                         }.foregroundColor(Theme.Colors.textPrimary)
                         Spacer()
                         UnitButtonView(type: .continueLesson, action: action)
@@ -44,13 +43,11 @@ struct ContinueWithView: View {
                         .padding(.top, 32)
                 } else {
                     VStack(alignment: .leading) {
-                        ContinueTitle(vertical: vertical)
+                        ContinueTitle(vertical: courseContinueUnit)
                             .foregroundColor(Theme.Colors.textPrimary)
                     }
                     UnitButtonView(type: .continueLesson, action: action)
                 }
-                
-            }
         }.padding(.horizontal, 24)
             .padding(.top, 32)
     }
@@ -61,7 +58,7 @@ private struct ContinueTitle: View {
     let vertical: CourseVertical
     
     var body: some View {
-        Text(CoreLocalization.Courseware.continueWith)
+        Text(CoreLocalization.Courseware.resumeWith)
             .font(Theme.Fonts.labelMedium)
             .foregroundColor(Theme.Colors.textSecondary)
         HStack {
@@ -78,55 +75,51 @@ private struct ContinueTitle: View {
 #if DEBUG
 struct ContinueWithView_Previews: PreviewProvider {
     static var previews: some View {
-        
-        let childs = [
-            CourseChapter(
-                blockId: "123",
-                id: "123",
-                displayName: "Continue lesson",
-                type: .chapter,
-                childs: [
-                    CourseSequential(
-                        blockId: "1",
-                        id: "1",
-                        displayName: "Name",
-                        type: .sequential,
-                        completion: 0,
-                        childs: [
-                            CourseVertical(
-                                blockId: "1",
-                                id: "1",
-                                courseId: "123",
-                                displayName: "Vertical",
-                                type: .vertical,
-                                completion: 0,
-                                childs: [
-                                    CourseBlock(
-                                        blockId: "2",
-                                        id: "2",
-                                        courseId: "123",
-                                        graded: true,
-                                        completion: 0,
-                                        type: .html,
-                                        displayName: "Continue lesson",
-                                        studentUrl: "")
-                                ])])])
+        let blocks = [
+            CourseBlock(
+                blockId: "1",
+                id: "1",
+                courseId: "123",
+                topicId: "1",
+                graded: false,
+                completion: 0,
+                type: .video,
+                displayName: "Lesson 1",
+                studentUrl: "",
+                videoUrl: nil,
+                youTubeUrl: nil
+            ),
+            CourseBlock(
+                blockId: "2",
+                id: "2",
+                courseId: "123",
+                topicId: "2",
+                graded: false,
+                completion: 0,
+                type: .video,
+                displayName: "Lesson 2",
+                studentUrl: "2",
+                videoUrl: nil,
+                youTubeUrl: nil
+            )
         ]
         
         ContinueWithView(
-            data: ContinueWith(chapterIndex: 0, sequentialIndex: 0, verticalIndex: 0),
-            courseStructure: CourseStructure(
-                id: "123",
-                graded: true,
-                completion: 0,
-                viewYouTubeUrl: "",
-                encodedVideo: "",
-                displayName: "Namaste",
-                childs: childs,
-                media: DataLayer.CourseMedia(
-                    image: .init(raw: "", small: "", large: "")
-                ),
-                certificate: nil)
+            data: ContinueWith(
+                chapterIndex: 0,
+                sequentialIndex: 0,
+                verticalIndex: 0,
+                lastVisitedBlockId: "test_block_id"
+            ),
+            courseContinueUnit: CourseVertical(
+                blockId: "2",
+                id: "2",
+                courseId: "123",
+                displayName: "Second Unit",
+                type: .vertical,
+                completion: 1,
+                childs: blocks
+            )
         ) {
         }
     }

--- a/Course/Course/Presentation/Outline/CourseOutlineView.swift
+++ b/Course/Course/Presentation/Outline/CourseOutlineView.swift
@@ -49,26 +49,39 @@ public struct CourseOutlineView: View {
                             if let continueWith = viewModel.continueWith,
                                let courseStructure = viewModel.courseStructure,
                                !isVideo {
+                                let chapter = courseStructure.childs[continueWith.chapterIndex]
+                                let sequential = chapter.childs[continueWith.sequentialIndex]
+                                let continueUnit = sequential.childs[continueWith.verticalIndex]
                                 
                                 // MARK: - ContinueWith button
                                 ContinueWithView(
                                     data: continueWith,
-                                    courseStructure: courseStructure
+                                    courseContinueUnit: continueUnit
                                 ) {
-                                    let chapter = courseStructure.childs[continueWith.chapterIndex]
-                                    let sequential = chapter.childs[continueWith.sequentialIndex]
+                                    var continueBlock: CourseBlock?
+                                    continueUnit.childs.forEach { block in
+                                        if block.id == continueWith.lastVisitedBlockId {
+                                            continueBlock = block
+                                        }
+                                    }
                                     
                                     viewModel.trackResumeCourseTapped(
-                                        blockId: sequential.childs[continueWith.verticalIndex].blockId
+                                        blockId: continueBlock?.id ?? ""
                                     )
-                                    viewModel.router.showCourseVerticalView(
-                                        courseID: courseStructure.id,
-                                        courseName: courseStructure.displayName,
-                                        title: sequential.displayName,
-                                        chapters: courseStructure.childs,
-                                        chapterIndex: continueWith.chapterIndex,
-                                        sequentialIndex: continueWith.sequentialIndex
-                                    )
+                                    
+                                    if let course = viewModel.courseStructure {
+                                        viewModel.router.showCourseUnit(
+                                            courseName: course.displayName,
+                                            blockId: continueBlock?.id ?? "",
+                                            courseID: course.id,
+                                            sectionName: continueUnit.displayName,
+                                            verticalIndex: continueWith.verticalIndex,
+                                            chapters: course.childs,
+                                            chapterIndex: continueWith.chapterIndex,
+                                            sequentialIndex: continueWith.sequentialIndex
+                                        )
+                                    }
+//"Saeed"
                                 }
                             }
                             

--- a/Course/Course/SwiftGen/Strings.swift
+++ b/Course/Course/SwiftGen/Strings.swift
@@ -27,8 +27,6 @@ public enum CourseLocalization {
     public static let backToOutline = CourseLocalization.tr("Localizable", "COURSEWARE.BACK_TO_OUTLINE", fallback: "Back to outline")
     /// Continue
     public static let `continue` = CourseLocalization.tr("Localizable", "COURSEWARE.CONTINUE", fallback: "Continue")
-    /// Continue with:
-    public static let continueWith = CourseLocalization.tr("Localizable", "COURSEWARE.CONTINUE_WITH", fallback: "Continue with:")
     /// Course content
     public static let courseContent = CourseLocalization.tr("Localizable", "COURSEWARE.COURSE_CONTENT", fallback: "Course content")
     /// Course units
@@ -43,6 +41,8 @@ public enum CourseLocalization {
     public static let next = CourseLocalization.tr("Localizable", "COURSEWARE.NEXT", fallback: "Next")
     /// Prev
     public static let previous = CourseLocalization.tr("Localizable", "COURSEWARE.PREVIOUS", fallback: "Prev")
+    /// Resume with:
+    public static let resumeWith = CourseLocalization.tr("Localizable", "COURSEWARE.RESUME_WITH", fallback: "Resume with:")
     /// Section “
     public static let section = CourseLocalization.tr("Localizable", "COURSEWARE.SECTION", fallback: "Section “")
   }

--- a/Course/Course/en.lproj/Localizable.strings
+++ b/Course/Course/en.lproj/Localizable.strings
@@ -28,7 +28,7 @@
 "COURSEWARE.SECTION" = "Section “";
 "COURSEWARE.IS_FINISHED" = "“ is finished.";
 "COURSEWARE.CONTINUE" = "Continue";
-"COURSEWARE.CONTINUE_WITH" = "Continue with:";
+"COURSEWARE.RESUME_WITH" = "Resume with:";
 
 "ERROR.NO_INTERNET" = "You are not connected to the Internet. Please check your Internet connection.";
 "ERROR.RELOAD" = "Reload";

--- a/Course/Course/uk.lproj/Localizable.strings
+++ b/Course/Course/uk.lproj/Localizable.strings
@@ -27,7 +27,7 @@
 "COURSEWARE.SECTION" = "Секція “";
 "COURSEWARE.IS_FINISHED" = "“ завершена.";
 "COURSEWARE.CONTINUE" = "Продовжити";
-"COURSEWARE.CONTINUE_WITH" = "Продовжити далі:";
+"COURSEWARE.RESUME_WITH" = "Продовжити далі:";
 
 "ERROR.NO_INTERNET" = "Ви не підключені до Інтернету. Перевірте підключення до Інтернету і спробуйте ще.";
 "ERROR.RELOAD" = "Перезавантажити";


### PR DESCRIPTION
This PR improves the course resume logic and navigates the learner to the last visited component screen. The last visited component is being returned from the server for API `/api/mobile/v1/users/\(userName)/course_status_info/\(courseID)`

Task Link:  [Remove Sequence units level from Resume action](https://github.com/openedx/openedx-app-ios/issues/199)

https://github.com/openedx/openedx-app-ios/assets/5606473/a052d244-d431-4c9b-b601-3ba5bf9e5422

