### PR TITLE
Open in browser button is partially hidden in landscape mode

### DIFF
--- a/Course/Course/Presentation/Unit/CourseUnitView.swift
+++ b/Course/Course/Presentation/Unit/CourseUnitView.swift
@@ -156,7 +156,7 @@ public struct CourseUnitView: View {
                                         case .unknown(let url):
                                             if index >= viewModel.index - 1 && index <= viewModel.index + 1 {
                                             if viewModel.connectivity.isInternetAvaliable {
-                                                ScrollView {
+                                                ScrollView(showsIndicators: false) {
                                                     UnknownView(url: url, viewModel: viewModel)
                                                     Spacer()
                                                         .frame(minHeight: 100)

--- a/Course/Course/Presentation/Unit/CourseUnitView.swift
+++ b/Course/Course/Presentation/Unit/CourseUnitView.swift
@@ -156,8 +156,11 @@ public struct CourseUnitView: View {
                                         case .unknown(let url):
                                             if index >= viewModel.index - 1 && index <= viewModel.index + 1 {
                                             if viewModel.connectivity.isInternetAvaliable {
-                                                UnknownView(url: url, viewModel: viewModel)
-                                                Spacer()
+                                                ScrollView {
+                                                    UnknownView(url: url, viewModel: viewModel)
+                                                    Spacer()
+                                                        .frame(minHeight: 100)
+                                                }
                                             } else {
                                                 NoInternetView(playerStateSubject: playerStateSubject)
                                             }


### PR DESCRIPTION
Small fix for https://github.com/openedx/openedx-app-ios/issues/186 bug
In landscape mode, the screen size is not enough to display the "Open in Browser" button if the content has a title. I've placed this "Unknown" view inside a scroll view.

https://github.com/openedx/openedx-app-ios/assets/37253/fde106b8-8a81-4b07-b2d5-b685909feb8c

