### PR TITLE
Theme/script improvements 

### DIFF
--- a/Documentation/Theming_implementation.md
+++ b/Documentation/Theming_implementation.md
@@ -77,13 +77,13 @@ assets:
 ```
 
 ### Font
-The config `whitelabel.yaml` can contain path to font file and existing font in project will be overriden with this font. 
-This ttf file should contain a few ttf font 'merged' into one ttf file. Font types are using in the app:
+The `whitelabel.yaml` configuration may contain the path to a font file, and an existing font in the project will be replaced with this font. 
+This ttf file must contain multiple ttf fonts "merged" into a single ttf file. Font types used in the application:
 - regular
 - medium
 - semiBold
 - bold
-For this feature the Config should contain next parameters:
+For this function, the configuration must contain the following parameters:
 ```yaml
 font:
     font_import_file_path: 'path/to/importing/Font_file.ttf' # path to ttf font file what should be imported to project

--- a/Documentation/Theming_implementation.md
+++ b/Documentation/Theming_implementation.md
@@ -83,6 +83,7 @@ This ttf file must contain multiple ttf fonts "merged" into a single ttf file. F
 - medium
 - semiBold
 - bold
+
 For this function, the configuration must contain the following parameters:
 ```yaml
 font:

--- a/Documentation/Theming_implementation.md
+++ b/Documentation/Theming_implementation.md
@@ -30,7 +30,7 @@ This config can contain the following options:
 ### Folder with source assets
 This is the folder where all image assets, which should be copied into the project, are placed (can be relative or absolute):
 ```yaml
-import_dir: 'path/to/images/source'
+images_import_dir: 'path/to/images/source'
 ```
 ### Xcode Project Settings
 The theming script can change the app name, version, development team and app bundle ID:
@@ -75,6 +75,27 @@ assets:
                 current_path: '' # optional: path to icon inside icon_path
                 image_name: 'appIcon.jpg' # image to replace the current AppIcon - png or jpg are supported
 ```
+
+### Font
+The config `whitelabel.yaml` can contain path to font file and existing font in project will be overriden with this font. 
+This ttf file should contain a few ttf font 'merged' into one ttf file. Font types are using in the app:
+- regular
+- medium
+- semiBold
+- bold
+For this feature the Config should contain next parameters:
+```yaml
+font:
+    font_import_file_path: 'path/to/importing/Font_file.ttf' # path to ttf font file what should be imported to project
+    project_font_file_path: 'path/to/font/file/in/project/font.ttf' # path to existing ttf font file in project
+    project_font_names_json_path: 'path/to/names/file/in project/fonts.json' # path to existing font names json-file in project
+    font_names:
+        regular: 'FontName-Regular'
+        medium: 'FontName-Medium'
+        semiBold: 'FontName-Semibold'
+        bold: 'FontName-Bold'
+```
+
 ### Log level
 You can set the log level to 'DEBUG' by adding the `-v` parameter to the script running.
 The default log level is 'WARN'

--- a/Documentation/Theming_implementation.md
+++ b/Documentation/Theming_implementation.md
@@ -38,6 +38,7 @@ The theming script can change the app name, version, development team and app bu
 project_config:
     project_path: 'path/to/project/project.pbxproj' # path to project.pbxproj file
     dev_team: '1234567890' # Apple development team ID
+    project_extra_targets: ['Target1', 'Target2'] # targets in the workspace other than 'OpenEdX' in which the new dev_team should be set
     marketing_version: '1.0.1' # App marketing version
     current_project_version: '2' # App build number
     configurations:

--- a/config_script/whitelabel.py
+++ b/config_script/whitelabel.py
@@ -418,18 +418,22 @@ class WhitelabelApp:
             logging.debug("Looks like DEVELOPMENT_TEAM for '"+target+"' target is set already")
     
     def copy_font(self):
+        # check if font config exists
         if self.font:
             if "font_import_file_path" in self.font:
                 font_import_file_path = self.font["font_import_file_path"]
                 if "project_font_file_path" in self.font:
                     project_font_file_path = self.font["project_font_file_path"]
+                    # if source and destination file exist
                     self.copy_font_file(font_import_file_path, project_font_file_path)
                 else:
                     logging.error("'project_font_file_path' not found in config")
             else:
                 logging.error("'font_import_file_path' not found in config")
+            # read font names from config
             if "font_names" in self.font:
                 font_names = self.font["font_names"]
+                # set font names
                 self.set_font_names(font_names)
             else:
                 logging.error("'font_names' not found in config")
@@ -437,6 +441,7 @@ class WhitelabelApp:
             logging.debug("Font not found in config")
 
     def copy_font_file(self, file_src, file_dest):
+        # try to copy font file and show success/error message
         try:
             shutil.copy(file_src, file_dest)
         except IOError as e:
@@ -447,13 +452,17 @@ class WhitelabelApp:
     def set_font_names(self, font_names):
         if "project_font_names_json_path" in self.font:
             project_font_names_json_path = self.font["project_font_names_json_path"]
+            # read names json file from project
             with open(project_font_names_json_path, 'r') as openfile:
                 json_object = json.load(openfile)
-            for key, value in json_object.items():
+            # go through font types and replace with values from config
+            for key, _ in json_object.items():
                 if key in font_names:
                     config_font_name_value = font_names[key]
                     json_object[key] = config_font_name_value
+            # generate new json
             new_json = json.dumps(json_object) 
+            # write to json file
             with open(project_font_names_json_path, 'w') as openfile:
                 openfile.write(new_json)
             logging.debug("Font names were set successfuly")


### PR DESCRIPTION
### Improvements for the `whitelabel.py` theme script 
- Added ability to specify which other targets in the project should receive the new development team ID (other than 'OpenEdX' by default) - this helps avoid build errors when deploying to a device in Xcode
- Added ability to override font in iOS app 
- Updated documentation to reflect the above changes

### Custom edX theme example

Clone `https://github.com/edx/edx-mobile-config` into the OpenEdX root folder and switch to the `anton/openedX-theming` branch.

From the OpenEdX root folder, run the script as:

```bash
python config_script/whitelabel.py --config-file=edx-mobile-config/openEdXAssets/whitelabel.yaml -v
```
Install on your simulator or device
All possible config parameters are described in [this documentation](https://github.com/touchapp/openedx-app-ios/blob/theme/script_improvements-/Documentation/Theming_implementation.md)