### PR TITLE
fix: navigation bar colors

### DIFF
--- a/Core/Core/Extensions/UIApplicationExtension.swift
+++ b/Core/Core/Extensions/UIApplicationExtension.swift
@@ -45,10 +45,10 @@ extension UINavigationController {
         navigationBar.shadowImage = UIImage()
         
         let image = CoreAssets.arrowLeft.image
-        navigationBar.backIndicatorImage = image.withTintColor(Theme.Colors.accentColor.uiColor())
+        navigationBar.backIndicatorImage = image.withTintColor(Theme.UIColors.accentColor)
         navigationBar.backItem?.backButtonTitle = " "
-        navigationBar.backIndicatorTransitionMaskImage = image.withTintColor(Theme.Colors.accentColor.uiColor())
-        navigationBar.titleTextAttributes = [.foregroundColor: Theme.Colors.textPrimary.uiColor()]
+        navigationBar.backIndicatorTransitionMaskImage = image.withTintColor(Theme.UIColors.accentColor)
+        navigationBar.titleTextAttributes = [.foregroundColor: Theme.UIColors.textPrimary]
     }
 }
 

--- a/Core/Core/Extensions/ViewExtension.swift
+++ b/Core/Core/Extensions/ViewExtension.swift
@@ -199,15 +199,6 @@ public extension View {
                 }
         }
     }
-    
-    func navigationBackground(color: UIColor) -> some View {
-        return self.introspect(
-            .navigationView(style: .stack),
-            on: .iOS(.v15...),
-            scope: .ancestor) {
-                $0.navigationBar.barTintColor = color
-            }
-    }
 
     func hideScrollContentBackground() -> some View {
         if #available(iOS 16.0, *) {

--- a/Core/Core/Extensions/ViewExtension.swift
+++ b/Core/Core/Extensions/ViewExtension.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import SwiftUIIntrospect
+@_spi(Advanced) import SwiftUIIntrospect
 import SwiftUI
 import Theme
 
@@ -193,13 +193,22 @@ public extension View {
         } else {
             return self.introspect(
                 .navigationView(style: .stack),
-                on: .iOS(.v14, .v15, .v16, .v17),
+                on: .iOS(.v15...),
                 scope: .ancestor) {
                     $0.isNavigationBarHidden = true
                 }
         }
     }
     
+    func navigationBackground(color: UIColor) -> some View {
+        return self.introspect(
+            .navigationView(style: .stack),
+            on: .iOS(.v15...),
+            scope: .ancestor) {
+                $0.navigationBar.barTintColor = color
+            }
+    }
+
     func hideScrollContentBackground() -> some View {
         if #available(iOS 16.0, *) {
             return self.scrollContentBackground(.hidden)

--- a/Core/Core/View/Base/ScrollSlidingTabBar/ScrollSlidingTabBar.swift
+++ b/Core/Core/View/Base/ScrollSlidingTabBar/ScrollSlidingTabBar.swift
@@ -163,8 +163,8 @@ extension ScrollSlidingTabBar {
         public static let `default` = Style(
             font: .body,
             selectedFont: .body.bold(),
-            activeAccentColor: Theme.Colors.accentColor ,
-            inactiveAccentColor: .black.opacity(0.4),
+            activeAccentColor: Theme.Colors.accentColor,
+            inactiveAccentColor: Theme.Colors.textSecondary,
             indicatorHeight: 2,
             borderColor: .gray.opacity(0.2),
             borderHeight: 1,

--- a/Core/Core/View/Base/WebUnitView.swift
+++ b/Core/Core/View/Base/WebUnitView.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import SwiftUIIntrospect
+@_spi(Advanced) import SwiftUIIntrospect
 import Theme
 
 public struct WebUnitView: View {
@@ -62,7 +62,7 @@ public struct WebUnitView: View {
                             .frame(width: reader.size.width, height: reader.size.height)
                         }
                     }
-                    .introspect(.scrollView, on: .iOS(.v14, .v15, .v16, .v17), customize: { scrollView in
+                    .introspect(.scrollView, on: .iOS(.v15...), customize: { scrollView in
                         scrollView.isScrollEnabled = false
                     })
                     if viewModel.updatingCookies || isWebViewLoading {

--- a/Course/Course/Presentation/Container/CourseContainerView.swift
+++ b/Course/Course/Presentation/Container/CourseContainerView.swift
@@ -84,6 +84,8 @@ public struct CourseContainerView: View {
         .navigationBarBackButtonHidden(false)
         .navigationTitle(titleBar())
         .onChange(of: selection, perform: didSelect)
+        .navigationBackground(color: Theme.UIColors.background)
+        .background(Theme.Colors.background)
     }
 
     @ViewBuilder

--- a/Course/Course/Presentation/Container/CourseContainerView.swift
+++ b/Course/Course/Presentation/Container/CourseContainerView.swift
@@ -84,7 +84,6 @@ public struct CourseContainerView: View {
         .navigationBarBackButtonHidden(false)
         .navigationTitle(titleBar())
         .onChange(of: selection, perform: didSelect)
-        .navigationBackground(color: Theme.UIColors.background)
         .background(Theme.Colors.background)
     }
 

--- a/Theme/Theme/Theme.swift
+++ b/Theme/Theme/Theme.swift
@@ -91,19 +91,17 @@ public struct Theme {
         }
     }
     
+    // Use this structure where the computed Color.uiColor() extension is not appropriate.
     public struct UIColors {
         public private(set) static var textPrimary = ThemeAssets.textPrimary.color
         public private(set) static var accentColor = ThemeAssets.accentColor.color
-        public private(set) static var background = ThemeAssets.background.color
 
         public static func update(
             textPrimary: UIColor = ThemeAssets.textPrimary.color,
-            accentColor: UIColor = ThemeAssets.accentColor.color,
-            background: UIColor = ThemeAssets.background.color
+            accentColor: UIColor = ThemeAssets.accentColor.color
         ) {
             self.textPrimary = textPrimary
             self.accentColor = accentColor
-            self.background = background
         }
     }
 

--- a/Theme/Theme/Theme.swift
+++ b/Theme/Theme/Theme.swift
@@ -91,6 +91,22 @@ public struct Theme {
         }
     }
     
+    public struct UIColors {
+        public private(set) static var textPrimary = ThemeAssets.textPrimary.color
+        public private(set) static var accentColor = ThemeAssets.accentColor.color
+        public private(set) static var background = ThemeAssets.background.color
+
+        public static func update(
+            textPrimary: UIColor = ThemeAssets.textPrimary.color,
+            accentColor: UIColor = ThemeAssets.accentColor.color,
+            background: UIColor = ThemeAssets.background.color
+        ) {
+            self.textPrimary = textPrimary
+            self.accentColor = accentColor
+            self.background = background
+        }
+    }
+
     public struct Fonts {
         
         public static let displayLarge: Font = .custom(fontsParser.fontName(for: .regular), size: 57)


### PR DESCRIPTION
This PR fixes bug with Navigation Bar background and title colors in dark mode. 
<img width="375" alt="295306543-aa89d0b1-3501-43a3-a317-d6f82b2fe70f" src="https://github.com/openedx/openedx-app-ios/assets/37253/edb45c31-b700-4d20-a91d-11fcde6373e5">

By some reason calculated UIColor doesn't work for navigation bar (like `Theme.Colors.textPrimary.uiColor()`) and I added UIColors struct into Theme.

After fix Navigation Bar looks like this:
<img width="375" alt="37253/6793dc56-1831-44c6-af30-11fc26d28cd2" src="https://github.com/openedx/openedx-app-ios/assets/37253/6793dc56-1831-44c6-af30-11fc26d28cd2">

 