### PR TITLE
Whats new page hidding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,4 +116,3 @@ venv/
 Podfile.lock
 config_settings.yaml
 default_config/
-default_config/config_settings.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ venv/
 Podfile.lock
 config_settings.yaml
 default_config/
+default_config/config_settings.yaml

--- a/Core/Core/Configuration/Config/UIComponentsConfig.swift
+++ b/Core/Core/Configuration/Config/UIComponentsConfig.swift
@@ -7,21 +7,24 @@
 
 import Foundation
 
-private enum Keys: String {
+private enum Keys: String, RawStringExtractable {
     case courseNestedListEnabled = "COURSE_NESTED_LIST_ENABLED"
     case courseTopTabBarEnabled = "COURSE_TOP_TAB_BAR_ENABLED"
     case courseBannerEnabled = "COURSE_BANNER_ENABLED"
+    case whatsNewImageOrTitlePageSkip = "WHATS_NEW_IMAGE_OR_TITLE_TO_SKIP_PAGE"
 }
 
 public class UIComponentsConfig: NSObject {
     public var courseNestedListEnabled: Bool = false
     public var courseBannerEnabled: Bool
     public var courseTopTabBarEnabled: Bool
+    public let whatsNewImageOrTitlePageSkip: String?
 
     init(dictionary: [String: Any]) {
         courseNestedListEnabled = dictionary[Keys.courseNestedListEnabled.rawValue] as? Bool ?? false
         courseBannerEnabled = dictionary[Keys.courseBannerEnabled.rawValue] as? Bool ?? false
         courseTopTabBarEnabled = dictionary[Keys.courseTopTabBarEnabled.rawValue] as? Bool ?? false
+        whatsNewImageOrTitlePageSkip = dictionary[Keys.whatsNewImageOrTitlePageSkip] as? String
         super.init()
     }
 }

--- a/Core/Core/Configuration/Config/UIComponentsConfig.swift
+++ b/Core/Core/Configuration/Config/UIComponentsConfig.swift
@@ -21,9 +21,9 @@ public class UIComponentsConfig: NSObject {
     public let whatsNewImageOrTitlePageSkip: String?
 
     init(dictionary: [String: Any]) {
-        courseNestedListEnabled = dictionary[Keys.courseNestedListEnabled.rawValue] as? Bool ?? false
-        courseBannerEnabled = dictionary[Keys.courseBannerEnabled.rawValue] as? Bool ?? false
-        courseTopTabBarEnabled = dictionary[Keys.courseTopTabBarEnabled.rawValue] as? Bool ?? false
+        courseNestedListEnabled = dictionary[Keys.courseNestedListEnabled] as? Bool ?? false
+        courseBannerEnabled = dictionary[Keys.courseBannerEnabled] as? Bool ?? false
+        courseTopTabBarEnabled = dictionary[Keys.courseTopTabBarEnabled] as? Bool ?? false
         whatsNewImageOrTitlePageSkip = dictionary[Keys.whatsNewImageOrTitlePageSkip] as? String
         super.init()
     }

--- a/OpenEdX/RouteController.swift
+++ b/OpenEdX/RouteController.swift
@@ -65,7 +65,7 @@ class RouteController: UIViewController {
         var storage = Container.shared.resolve(WhatsNewStorage.self)!
         let config = Container.shared.resolve(ConfigProtocol.self)!
 
-        let viewModel = WhatsNewViewModel(storage: storage)
+        let viewModel = WhatsNewViewModel(storage: storage, config: config)
         let shouldShowWhatsNew = viewModel.shouldShowWhatsNew()
 
         if shouldShowWhatsNew && config.features.whatNewEnabled {

--- a/OpenEdX/Router.swift
+++ b/OpenEdX/Router.swift
@@ -63,7 +63,7 @@ public class Router: AuthorizationRouter,
         var storage = Container.shared.resolve(WhatsNewStorage.self)!
         let config = Container.shared.resolve(ConfigProtocol.self)!
 
-        let viewModel = WhatsNewViewModel(storage: storage, sourceScreen: sourceScreen)
+        let viewModel = WhatsNewViewModel(storage: storage, sourceScreen: sourceScreen, config: config)
         let whatsNew = WhatsNewView(router: Container.shared.resolve(WhatsNewRouter.self)!, viewModel: viewModel)
         let shouldShowWhatsNew = viewModel.shouldShowWhatsNew()
                

--- a/WhatsNew/WhatsNew/Data/WhatsNewModel.swift
+++ b/WhatsNew/WhatsNew/Data/WhatsNewModel.swift
@@ -39,10 +39,8 @@ extension WhatsNewModel {
         let v1 = version1.split(separator: ".").compactMap { Int($0) }
         let v2 = version2.split(separator: ".").compactMap { Int($0) }
 
-        for (a, b) in zip(v1, v2) {
-            if a != b {
-                return a < b ? .orderedAscending : .orderedDescending
-            }
+        for (a, b) in zip(v1, v2) where a != b {
+            return a < b ? .orderedAscending : .orderedDescending
         }
 
         return v1.count < v2.count ? .orderedAscending : (v1.count > v2.count ? .orderedDescending : .orderedSame)
@@ -54,7 +52,6 @@ extension WhatsNewModel {
         }
         return latestVersion
     }
-    
     
     var domain: [WhatsNewPage] {
         guard let latestVersion = findLatestVersion(self.map { $0.version }) else { return [] }

--- a/WhatsNew/WhatsNew/Presentation/WhatsNewView.swift
+++ b/WhatsNew/WhatsNew/Presentation/WhatsNewView.swift
@@ -153,7 +153,7 @@ struct WhatsNewView_Previews: PreviewProvider {
     static var previews: some View {
         WhatsNewView(
             router: WhatsNewRouterMock(),
-            viewModel: WhatsNewViewModel(storage: WhatsNewStorageMock())
+            viewModel: WhatsNewViewModel(storage: WhatsNewStorageMock(), config: ConfigMock())
         )
         .loadFonts()
     }

--- a/WhatsNew/WhatsNew/Presentation/WhatsNewViewModel.swift
+++ b/WhatsNew/WhatsNew/Presentation/WhatsNewViewModel.swift
@@ -59,9 +59,8 @@ public class WhatsNewViewModel: ObservableObject {
         if let imageOrTitle = config.uiComponents.whatsNewImageOrTitlePageSkip,
             !imageOrTitle.isEmpty {
             return domain.filter { $0.image != imageOrTitle && $0.title != imageOrTitle }
-        } else {
-            return domain
         }
+        return domain
     }
     
     private func loadWhatsNewModel() -> WhatsNewModel? {

--- a/WhatsNew/WhatsNew/Presentation/WhatsNewViewModel.swift
+++ b/WhatsNew/WhatsNew/Presentation/WhatsNewViewModel.swift
@@ -14,10 +14,12 @@ public class WhatsNewViewModel: ObservableObject {
     @Published var newItems: [WhatsNewPage] = []
     private let storage: WhatsNewStorage
     var sourceScreen: LogistrationSourceScreen
+    private let config: ConfigProtocol
     
-    public init(storage: WhatsNewStorage, sourceScreen: LogistrationSourceScreen = .default) {
+    public init(storage: WhatsNewStorage, sourceScreen: LogistrationSourceScreen = .default, config: ConfigProtocol) {
         self.storage = storage
         self.sourceScreen = sourceScreen
+        self.config = config
         newItems = loadWhatsNew()
     }
     
@@ -54,7 +56,12 @@ public class WhatsNewViewModel: ObservableObject {
     
     func loadWhatsNew() -> [WhatsNewPage] {
         guard let domain = loadWhatsNewModel()?.domain else { return [] }
-        return domain
+        if let imageOrTitle = config.uiComponents.whatsNewImageOrTitlePageSkip,
+            !imageOrTitle.isEmpty {
+            return domain.filter { $0.image != imageOrTitle && $0.title != imageOrTitle }
+        } else {
+            return domain
+        }
     }
     
     private func loadWhatsNewModel() -> WhatsNewModel? {

--- a/WhatsNew/WhatsNewTests/Presentation/WhatsNewTests.swift
+++ b/WhatsNew/WhatsNewTests/Presentation/WhatsNewTests.swift
@@ -6,21 +6,23 @@
 //
 
 import XCTest
+import Core
 @testable import WhatsNew
 
 final class WhatsNewTests: XCTestCase {
 
     func testGetVersion() throws {
-     let viewModel = WhatsNewViewModel(storage: WhatsNewStorageMock())
+        let config = ConfigMock()
+        let viewModel = WhatsNewViewModel(storage: WhatsNewStorageMock(), config: config)
         let version = viewModel.getVersion()
         XCTAssertNotNil(version)
         XCTAssertTrue(version == "1.0")
     }
     
     func testshouldShowWhatsNew() throws {
-     let viewModel = WhatsNewViewModel(storage: WhatsNewStorageMock())
+        let config = ConfigMock()
+        let viewModel = WhatsNewViewModel(storage: WhatsNewStorageMock(), config: config)
         let version = viewModel.getVersion()
-        
         XCTAssertNotNil(version)
         XCTAssertTrue(viewModel.shouldShowWhatsNew())
     }

--- a/config_script/process_config.py
+++ b/config_script/process_config.py
@@ -68,7 +68,7 @@ class PlistManager:
                 with open(path, 'r') as file:
                     dict = yaml.safe_load(file)
                     if dict is not None:
-                        properties.update(dict)
+                        properties = merge_dicts(properties, dict)
             except FileNotFoundError:
                 print(f"{path} not found. Skipping.")
 
@@ -82,7 +82,7 @@ class PlistManager:
                 with open(path, 'r') as file:
                     yaml_data = yaml.safe_load(file)
                     if yaml_data is not None:
-                        plist_data.update(yaml_data)
+                        plist_data = merge_dicts(plist_data, yaml_data)
             except FileNotFoundError:
                 print(f"{path} not found. Skipping.")
             except yaml.YAMLError as e:
@@ -117,7 +117,14 @@ class PlistManager:
         except Exception as e:
             print(f"Error reading plist file: {e}")
             return None
-            
+
+def merge_dicts(d1, d2):
+    for k, v in d2.items():
+        if k in d1:
+            d1[k] = dict(v,**d1[k])
+        else:
+            d1[k] = v
+    return d1
 
 class ConfigurationManager:
     def __init__(self, plist_manager):


### PR DESCRIPTION
PR for https://github.com/openedx/openedx-app-ios/issues/224
Added FF `WHATS_NEW_IMAGE_OR_TITLE_TO_SKIP_PAGE` - it can contain the image name or page title from the What's new JSON file. Pages with such image name or title will be skipped in the What's new function.
To test you can use this config `https://github.com/edx/edx-mobile-config/tree/anton/whatsnew` or add this to `shared.yaml` manually like:
```yaml
UI_COMPONENTS:
    WHATS_NEW_IMAGE_OR_TITLE_TO_SKIP_PAGE: 'Learning Site Switching'
```
The `process_config.py` script has also been changed, it will now try to merge dictionaries from different files (e.g. `iOS.yaml` and `shared.yaml`) if both files have the same section with children in them 