### PR TITLE
chore: configure branch via info.plist

### DIFF
--- a/OpenEdX/Managers/DeepLinkManager/Services/BranchService.swift
+++ b/OpenEdX/Managers/DeepLinkManager/Services/BranchService.swift
@@ -17,15 +17,12 @@ class BranchService: DeepLinkService {
         config: ConfigProtocol,
         launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) {
-        guard let key = config.branch.key, config.branch.enabled else { return }
-        Branch.setBranchKey(key)
+        guard config.branch.enabled && config.branch.key != nil else { return }
         
-        if Branch.branchKey() != nil {
-            Branch.getInstance().initSession(launchOptions: launchOptions) { params, error in
-                guard let params = params, error == nil else { return }
-             
-                manager.processDeepLink(with: params)
-            }
+        Branch.getInstance().initSession(launchOptions: launchOptions) { params, error in
+            guard let params = params, error == nil else { return }
+            
+            manager.processDeepLink(with: params)
         }
     }
     

--- a/config_script/process_config.py
+++ b/config_script/process_config.py
@@ -197,6 +197,8 @@ class ConfigurationManager:
         enabled = branch.get('ENABLED')
         uriScheme = branch.get('URI_SCHEME')
         prefix = branch.get('DEEPLINK_PREFIX')
+        key = branch.get('KEY')
+        testKey = branch.get('KEY_TEST')
         
         if not prefix:
             prefix = "edx"
@@ -207,7 +209,19 @@ class ConfigurationManager:
             else:
                 bundle_identifier = self.plist_manager.get_bundle_identifier()
                 scheme = [bundle_identifier]
-            
+                
+                if key:
+                    branch_key = {
+                        'live': key
+                    }
+
+                    if testKey:
+                        branch_key['test'] = testKey
+                    else:
+                        branch_key['test'] = key
+
+                    plist['branch_key'] = branch_key
+                
             self.add_custom_array("branch_universal_link_domains", [
                 prefix+".app.link",
                 prefix+"-alternate.app.link",


### PR DESCRIPTION
In the [production codebase](https://github.com/openedx/dx-app-ios) we were using `Branch.setBranchKey(key)` to set the branch key and it was working as expected.

But with the new version of the branch SDK `3.x.x`, it seems it's no longer working and requires the keys to be added in the info.plist.

This PR fixes it and now the branch keys are being added to the info.plist via config_process script on compile time.

### Config
```
BRANCH:
    ENABLED: true
    KEY: 'key_live'
   `KEY_TEST`: 'key_test' # if this be missing KEY will be used as live and test keys and it works.
 
   ```