### PR TITLE
fix: [iOS] The symbol ' in subtitles is displayed as an ASCII code

### DIFF
--- a/Core/Core/Extensions/StringExtension.swift
+++ b/Core/Core/Extensions/StringExtension.swift
@@ -55,4 +55,31 @@ public extension String {
         }
         return urls
     }
+
+    func decodedHTMLEntities() -> String {
+        guard let regex = try? NSRegularExpression(pattern: "&#([0-9]+);", options: []) else {
+            return self
+        }
+
+        let range = NSRange(location: 0, length: count)
+        let matches = regex.matches(in: self, options: [], range: range)
+        
+        var decodedString = self
+        for match in matches {
+            guard match.numberOfRanges > 1,
+                  let range = Range(match.range(at: 1), in: self),
+                  let codePoint = Int(self[range]),
+                  let unicodeScalar = UnicodeScalar(codePoint) else {
+                continue
+            }
+            
+            let replacement = String(unicodeScalar)
+            guard let totalRange = Range(match.range, in: self) else {
+                continue
+            }
+            decodedString = decodedString.replacingOccurrences(of: self[totalRange], with: replacement)
+        }
+        
+        return decodedString
+    }
 }

--- a/Course/Course/Domain/CourseInteractor.swift
+++ b/Course/Course/Domain/CourseInteractor.swift
@@ -187,7 +187,7 @@ public class CourseInteractor: CourseInteractorProtocol {
                 let subtitle = Subtitle(id: id,
                                         fromTo: DateInterval(start: Date(subtitleTime: startTime),
                                                              end: Date(subtitleTime: endTime)),
-                                        text: text)
+                                        text: text.decodedHTMLEntities())
                 subtitles.append(subtitle)
             }
         }


### PR DESCRIPTION
[iOS] The symbol ' in subtitles is displayed as an ASCII code #334