### PR TITLE
feat: Calendar deep link to course component

### DIFF
--- a/OpenEdX/Managers/DeepLinkManager/DeepLinkManager.swift
+++ b/OpenEdX/Managers/DeepLinkManager/DeepLinkManager.swift
@@ -204,6 +204,19 @@ public class DeepLinkManager {
             router.showTabScreen(tab: .profile)
         case .userProfile:
             await showEditProfile()
+        case .courseComponent:
+            guard let courseID = link.courseID else { return }
+            do {
+                let courseStructure = try await courseInteractor.getLoadedCourseBlocks(courseID: courseID)
+                router.showCourseComponent(
+                    componentID: link.componentID ?? "",
+                    courseStructure: courseStructure,
+                    blockLink: ""
+                )
+                router.showTabScreen(tab: .dashboard)
+            } catch {
+                router.dismissProgress()
+            }
         default:
             break
         }

--- a/OpenEdX/Managers/DeepLinkManager/DeepLinkRouter/DeepLinkRouter.swift
+++ b/OpenEdX/Managers/DeepLinkManager/DeepLinkRouter/DeepLinkRouter.swift
@@ -25,6 +25,11 @@ public protocol DeepLinkRouter: BaseRouter {
         courseDetails: CourseDetails,
         completion: @escaping () -> Void
     )
+    func showCourseComponent(
+        componentID: String,
+        courseStructure: CourseStructure,
+        blockLink: String
+    )
     func showAnnouncement(
         courseDetails: CourseDetails,
         updates: [CourseUpdate]
@@ -325,6 +330,11 @@ public class DeepLinkRouterMock: BaseRouterMock, DeepLinkRouter {
         link: DeepLink,
         courseDetails: CourseDetails,
         completion: @escaping () -> Void
+    ) {}
+    public func showCourseComponent(
+        componentID: String,
+        courseStructure: CourseStructure,
+        blockLink: String
     ) {}
     public func showAnnouncement(
         courseDetails: CourseDetails,

--- a/OpenEdX/Managers/DeepLinkManager/DeepLinkRouter/DeepLinkRouter.swift
+++ b/OpenEdX/Managers/DeepLinkManager/DeepLinkRouter/DeepLinkRouter.swift
@@ -126,7 +126,8 @@ extension Router: DeepLinkRouter {
             .discussions,
             .courseHandout,
             .courseAnnouncement,
-            .courseDashboard:
+            .courseDashboard,
+            .courseComponent:
             popToCourseContainerView(animated: false)
         default:
             break
@@ -138,7 +139,7 @@ extension Router: DeepLinkRouter {
                 self.hostCourseContainerView?.rootView.viewModel.selection = CourseTab.course.rawValue
             case .courseVideos:
                 self.hostCourseContainerView?.rootView.viewModel.selection = CourseTab.videos.rawValue
-            case .courseDates:
+            case .courseDates, .courseComponent:
                 self.hostCourseContainerView?.rootView.viewModel.selection = CourseTab.dates.rawValue
             case .discussions, .discussionTopic, .discussionPost, .discussionComment:
                 self.hostCourseContainerView?.rootView.viewModel.selection = CourseTab.discussion.rawValue


### PR DESCRIPTION
[LEARNER-9888](https://2u-internal.atlassian.net/browse/LEARNER-9888): Navigate to a particular course component upon tapping the link from the native calendar application synced with the calendar for that specific course.

**Demo:**

https://github.com/openedx/openedx-app-ios/assets/11990137/d83276a7-98a3-4bb9-80e1-d6e0e0cd688e