### PR TITLE
fix: rolled back test value

### DIFF
--- a/OpenEdX/Router.swift
+++ b/OpenEdX/Router.swift
@@ -138,7 +138,7 @@ public class Router: AuthorizationRouter,
               connectivity.isInternetAvaliable
         else { return }
         let vm = AppReviewViewModel(config: config, storage: storage, analytics: analytics)
-        if true {
+        if vm.shouldShowRatingView() {
             presentView(
                 transitionStyle: .crossDissolve,
                 view: AppReviewView(viewModel: vm)


### PR DESCRIPTION
The test value[ in this PR](https://github.com/openedx/openedx-app-ios/commit/3531fc2#diff-2b25a8034888f1572195662d18b46ec140dd9b62b15ea2f9710bdf8f7a7d63f8L135) was erroneously merged into develop
