### PR TITLE
chore: add maintainership documentation

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,16 @@
+# This file records information about this repo. Its use is described in OEP-55:
+# https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055-proc-project-maintainers.html
+
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: 'openedx-app-ios'
+  description: "The mobile app for iOS for the Open EdX Platform"
+  links:
+    - url: "https://github.com/openedx/openedx-app-ios/tree/main/Documentation"
+      title: "Documentation"
+      icon: "PhoneIphone"
+spec:
+  owner: group:openedx-mobile-maintainers
+  type: 'mobile'
+  lifecycle: 'production'


### PR DESCRIPTION
Adding `catalog-info.yaml` according to [OEP-55](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0055-proc-project-maintainers.html).