### PR TITLE
fix: Maintain calendar toggle and local calendar event mapping

### DIFF
--- a/Core/Core/Extensions/DateExtension.swift
+++ b/Core/Core/Extensions/DateExtension.swift
@@ -11,6 +11,7 @@ import Foundation
 public extension Date {
     init(iso8601: String) {
         let formats = ["yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ"]
+        let calender = Calendar.current
         var date: Date
         var dateFormatter: DateFormatter?
         dateFormatter = DateFormatter()
@@ -18,7 +19,12 @@ public extension Date {
         
         date = formats.compactMap { format in
             dateFormatter?.dateFormat = format
-            return dateFormatter?.date(from: iso8601)
+            guard let formattedDate = dateFormatter?.date(from: iso8601) else { return nil }
+            let components = calender.dateComponents(
+                [.year, .month, .day, .hour, .minute, .second],
+                from: formattedDate
+            )
+            return calender.date(from: components)
         }
         .first ?? Date()
         


### PR DESCRIPTION
[LEARNER-9936](https://2u-internal.atlassian.net/browse/LEARNER-9936): iOS - Maintain calendar toggle and local calendar event mapping

In this pull request, we tackled the following two issues:
- Resolved an outdated calendar alert while upgrading the production application to the new application.
- Corrected the display of identical date calendar events appearing in two sections due to nanosecond disparities.
Screenshots highlight these discrepancies.

### Within edX Application
| Before | After |
|----------|----------|
| ![Simulator Screenshot - iPhone 15 - 2024-04-19 at 19 54 47](https://github.com/openedx/openedx-app-ios/assets/11990137/af1d7582-a187-4f47-9e23-3b55ec9aa70f) | ![Simulator Screenshot - iPhone 15 - 2024-04-19 at 19 53 49](https://github.com/openedx/openedx-app-ios/assets/11990137/34e9f280-375e-458e-9a86-3f48447350da) |

### Within Calendar Native Application
| Before | After |
|----------|----------|
| ![Untitled](https://github.com/openedx/openedx-app-ios/assets/11990137/189e9b76-a22b-45a6-a3ab-af5cd249988b) | ![Untitled 2](https://github.com/openedx/openedx-app-ios/assets/11990137/5186730d-cad9-4e70-949a-838ba6d6bef1) |