### PR TITLE
feat: atlas pull and push scripts | FC-55

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,9 @@ venv/
 Podfile.lock
 config_settings.yaml
 default_config/
+
+# Translations ignored files
+.venv/
+I18N/
+*.lproj/
+!en.lproj/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+clean_translations_temp_directory:
+	rm -rf I18N/
+
+translation_requirements:
+	pip3 install -r i18n_scripts/requirements.txt
+
+pull_translations: clean_translations_temp_directory
+	atlas pull $(ATLAS_OPTIONS) translations/openedx-app-ios/I18N:I18N
+	python3 i18n_scripts/translation.py --split --replace-underscore
+
+extract_translations: clean_translations_temp_directory
+	python3 i18n_scripts/translation.py --combine

--- a/README.md
+++ b/README.md
@@ -19,6 +19,47 @@ Modern vision of the mobile application for the Open edX platform from Raccoon G
 
 6. Click the **Run** button.
 
+## Translations
+### Getting translations for the app
+Translations aren't included in the source code of this repository as of [OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html). Therefore, they need to be pulled before testing or publishing to App Store.
+
+Before retrieving the translations for the app, we need to install the requirements listed in the requirements.txt file located in the i18n_scripts directory. This can be done easily by running the following make command:
+```bash
+make translation_requirements
+```
+
+Then, to get the latest translations for all languages use the following command:
+```bash
+make pull_translations
+```
+This command runs [`atlas pull`](https://github.com/openedx/openedx-atlas) to download the latest translations files from the [openedx/openedx-translations](https://github.com/openedx/openedx-translations) repository. These files contain the latest translations for all languages. In the [openedx/openedx-translations](https://github.com/openedx/openedx-translations) repository each language's translations are saved as a single file e.g. `I18N/I18N/uk.lproj/Localization.strings` ([example](https://github.com/openedx/openedx-translations/blob/6448167e9695a921f003ff6bd8f40f006a2d6743/translations/openedx-app-ios/I18N/I18N/uk.lproj/Localizable.strings)). After these are pulled, each language's translation file is split into the App's modules e.g. `Discovery/Discovery/uk.lproj/Localization.strings`.
+   
+  After this command is run the application can load the translations by changing the device (or the emulator) language in the settings.
+
+### Using custom translations
+
+By default, the command `make pull_translations` runs [`atlas pull`](https://github.com/openedx/openedx-atlas) with no arguments which pulls transaltions from the [openedx-translations repository](https://github.com/openedx/openedx-translations).
+
+You can use custom translations on your fork of the openedx-translations repository by setting the following configuration parameters:
+
+- `--revision` (default: `"main"`): Branch or git tag to pull translations from.
+- `--repository` (default: `"openedx/openedx-translations"`): GitHub repository slug. There's a feature request to [support GitLab and other providers](https://github.com/openedx/openedx-atlas/issues/20).
+
+Arguments can be passed via the `ATLAS_OPTIONS` environment variable as shown below:
+``` bash
+make ATLAS_OPTIONS='--repository=<your-github-org>/<repository-name> --revision=<branch-name>' pull_translations
+```
+Additional arguments can be passed to `atlas pull`. Refer to the [atlas documentations ](https://github.com/openedx/openedx-atlas) for more information.
+
+### How to translate the app
+	
+Translations are managed in the [open-edx/openedx-translations](https://app.transifex.com/open-edx/openedx-translations/dashboard/) Transifex project.
+
+To translate the app join the [Transifex project](https://app.transifex.com/open-edx/openedx-translations/dashboard/) and add your translations `openedx-app-ios` resource: https://app.transifex.com/open-edx/openedx-translations/openedx-app-ios/ (the link will start working after the [pull request #442](https://github.com/openedx/openedx-app-ios/pull/422) is merged)
+
+Once the resource is both 100% translated and reviewed the [Transifex integration](https://github.com/apps/transifex-integration) will automatically push it to the [openedx-translations](https://github.com/openedx/openedx-translations) repository and developers can use the translations in their app.
+
+
 ## API
 This project targets on the latest Open edX release and rely on the relevant mobile APIs.
 

--- a/i18n_scripts/requirements.txt
+++ b/i18n_scripts/requirements.txt
@@ -1,0 +1,3 @@
+# Translation processing dependencies
+openedx-atlas==0.6.1
+localizable==0.1.3

--- a/i18n_scripts/translation.py
+++ b/i18n_scripts/translation.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""
+This script performs two jobs:
+ 1- Combine the English translations from all modules in the repository to the I18N directory. After the English
+    translation is combined, it will be pushed to the openedx-translations repository as described in OEP-58.
+2- Split the pulled translation files from the openedx-translations repository into the iOS app modules.
+
+More detailed specifications are described in the docs/0002-atlas-translations-management.rst design doc.
+"""
+
+import argparse
+import os
+import re
+import sys
+from collections import defaultdict
+import localizable
+
+
+def parse_arguments():
+    """
+    This function is the argument parser for this script.
+    The script takes only one of the two arguments --split or --combine.
+    Additionally, the --replace-underscore argument can only be used with --split.
+    """
+    parser = argparse.ArgumentParser(description='Split or Combine translations.')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--split', action='store_true',
+                       help='Split translations into separate files for each module and language.')
+    group.add_argument('--combine', action='store_true',
+                       help='Combine the English translations from all modules into a single file.')
+    parser.add_argument('--replace-underscore', action='store_true',
+                        help='Replace underscores with "-r" in language directories (only with --split).')
+    return parser.parse_args()
+
+
+def get_translation_file_path(modules_dir, module_name, lang_dir, create_dirs=False):
+    """
+    Retrieves the path of the translation file for a specified module and language directory.
+
+    Parameters:
+        modules_dir (str): The path to the base directory containing all the modules.
+        module_name (str): The name of the module for which the translation path is being retrieved.
+        lang_dir (str): The name of the language directory within the module's directory.
+        create_dirs (bool): If True, creates the parent directories if they do not exist. Defaults to False.
+
+    Returns:
+        str: The path to the module's translation file (Localizable.strings).
+    """
+    try:
+        lang_dir_path = os.path.join(modules_dir, module_name, module_name, lang_dir, 'Localizable.strings')
+        if create_dirs:
+            os.makedirs(os.path.dirname(lang_dir_path), exist_ok=True)
+        return lang_dir_path
+    except Exception as e:
+        print(f"Error creating directory path: {e}", file=sys.stderr)
+        raise
+
+
+def get_modules_to_translate(modules_dir):
+    """
+    Retrieve the names of modules that have translation files for a specified language.
+
+    Parameters:
+        modules_dir (str): The path to the directory containing all the modules.
+
+    Returns:
+        list of str: A list of module names that have translation files for the specified language.
+    """
+    try:
+        modules_list = [
+            directory for directory in os.listdir(modules_dir)
+            if (
+                os.path.isdir(os.path.join(modules_dir, directory))
+                and os.path.isfile(get_translation_file_path(modules_dir, directory, 'en.lproj'))
+                and directory != 'I18N'
+            )
+        ]
+        return modules_list
+    except FileNotFoundError as e:
+        print(f"Directory not found: {e}", file=sys.stderr)
+        raise
+    except PermissionError as e:
+        print(f"Permission denied: {e}", file=sys.stderr)
+        raise
+
+
+def get_translations(modules_dir):
+    """
+    Retrieve the translations from all modules in the modules_dir.
+
+    Parameters:
+        modules_dir (str): The directory containing the modules.
+
+    Returns:
+        dict: A dict containing a list of dictionaries containing the 'key', 'value', and 'comment' for each
+        translation line. The key of the outer dict is the name of the module where the translations are going
+        to be saved.
+    """
+    translations = []
+    try:
+        modules = get_modules_to_translate(modules_dir)
+        for module in modules:
+            translation_file = get_translation_file_path(modules_dir, module, lang_dir='en.lproj')
+            module_translation = localizable.parse_strings(filename=translation_file)
+
+            translations += [
+                {
+                    'key': f"{module}.{translation_entry['key']}",
+                    'value': translation_entry['value'],
+                    'comment': translation_entry['comment']
+                } for translation_entry in module_translation
+            ]
+    except Exception as e:
+        print(f"Error retrieving translations: {e}", file=sys.stderr)
+        raise
+
+    return {'I18N': translations}
+
+
+def combine_translation_files(modules_dir=None):
+    """
+    Combine translation files from different modules into a single file.
+    """
+    try:
+        if not modules_dir:
+            modules_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        translation = get_translations(modules_dir)
+        write_translations_to_modules(modules_dir, 'en.lproj', translation)
+    except Exception as e:
+        print(f"Error combining translation files: {e}", file=sys.stderr)
+        raise
+
+
+def get_languages_dirs(modules_dir):
+    """
+    Retrieve directories containing language files for translation.
+
+    Args:
+        modules_dir (str): The directory containing all the modules.
+
+    Returns:
+        list: A list of directories containing language files for translation. Each directory represents
+              a specific language and ends with the '.lproj' extension.
+    """
+    try:
+        lang_parent_dir = os.path.join(modules_dir, 'I18N', 'I18N')
+        languages_dirs = [
+            directory for directory in os.listdir(lang_parent_dir)
+            if directory.endswith('.lproj') and directory != "en.lproj"
+        ]
+        return languages_dirs
+    except FileNotFoundError as e:
+        print(f"Directory not found: {e}", file=sys.stderr)
+        raise
+    except PermissionError as e:
+        print(f"Permission denied: {e}", file=sys.stderr)
+        raise
+
+
+def get_translations_from_file(modules_dir, lang_dir):
+    """
+    Get translations from the translation file in the 'I18N' directory and distribute them into the appropriate
+    modules' directories.
+
+    Args:
+        modules_dir (str): The directory containing all the modules.
+        lang_dir (str): The directory containing the translation file being split.
+
+    Returns:
+        dict: A dictionary containing translations split by module. The keys are module names,
+              and the values are lists of dictionaries, each containing the 'key', 'value', and 'comment'
+              for each translation entry within the module.
+    """
+    translations = defaultdict(list)
+    try:
+        translations_file_path = get_translation_file_path(modules_dir, 'I18N', lang_dir)
+        lang_list = localizable.parse_strings(filename=translations_file_path)
+        for translation_entry in lang_list:
+            module_name, key_remainder = translation_entry['key'].split('.', maxsplit=1)
+            split_entry = {
+                'key': key_remainder,
+                'value': translation_entry['value'],
+                'comment': translation_entry['comment']
+            }
+            translations[module_name].append(split_entry)
+    except Exception as e:
+        print(f"Error extracting translations from file: {e}", file=sys.stderr)
+        raise
+    return translations
+
+
+def write_translations_to_modules(modules_dir, lang_dir, modules_translations):
+    """
+    Write translations to language files for each module.
+
+    Args:
+        modules_dir (str): The directory containing all the modules.
+        lang_dir (str): The directory of the translation file being written.
+        modules_translations (dict): A dictionary containing translations for each module.
+
+    Returns:
+        None
+    """
+    for module, translation_list in modules_translations.items():
+        try:
+            translation_file_path = get_translation_file_path(modules_dir, module, lang_dir, create_dirs=True)
+            with open(translation_file_path, 'w') as f:
+                for translation_entry in translation_list:
+                    write_line_and_comment(f, translation_entry)
+        except Exception as e:
+            print(f"Error writing translations to file.\n Module: {module}\n Error: {e}", file=sys.stderr)
+            raise
+
+
+def _escape(s):
+    """
+    Reverse the replacements performed by _unescape() in the localizable library
+    """
+    s = s.replace('\n', r'\n').replace('\r', r'\r').replace('"', r'\"')
+    return s
+
+
+def write_line_and_comment(f, entry):
+    """
+    Write a translation line with an optional comment to a file.
+
+    Args:
+        file (file object): The file object to write to.
+        entry (dict): A dictionary containing the translation entry with 'key', 'value', and optional 'comment'.
+
+    Returns:
+        None
+    """
+    comment = entry.get('comment')  # Retrieve the comment, if present
+    if comment:
+        f.write(f"/* {comment} */\n")
+    f.write(f'"{entry["key"]}" = "{_escape(entry["value"])}";\n')
+
+
+def split_translation_files(modules_dir=None):
+    """
+    Split translation files into separate files for each module and language.
+
+    Args:
+        modules_dir (str, optional): The directory containing all the modules. If not provided,
+            it defaults to the parent directory of the directory containing this script.
+
+    Returns:
+        None
+    """
+    try:
+        if not modules_dir:
+            modules_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        languages_dirs = get_languages_dirs(modules_dir)
+        for lang_dir in languages_dirs:
+            translations = get_translations_from_file(modules_dir, lang_dir)
+            write_translations_to_modules(modules_dir, lang_dir, translations)
+    except Exception as e:
+        print(f"Error splitting translation files: {e}", file=sys.stderr)
+        raise
+
+
+def replace_underscores(modules_dir=None):
+    try:
+        if not modules_dir:
+            modules_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+        languages_dirs = get_languages_dirs(modules_dir)
+
+        for lang_dir in languages_dirs:
+            try:
+                pattern = r'_(\w\w.lproj$)'
+                if re.search(pattern, lang_dir):
+                    replacement = r'-\1'
+                    new_name = re.sub(pattern, replacement, lang_dir)
+                    lang_old_path = os.path.dirname(get_translation_file_path(modules_dir, 'I18N', lang_dir))
+                    lang_new_path = os.path.dirname(get_translation_file_path(modules_dir, 'I18N', new_name))
+
+                    os.rename(lang_old_path, lang_new_path)
+                    print(f"Renamed {lang_old_path} to {lang_new_path}")
+
+            except FileNotFoundError as e:
+                print(f"Error: The file or directory {lang_old_path} does not exist: {e}", file=sys.stderr)
+                raise
+            except PermissionError as e:
+                print(f"Error: Permission denied while renaming {lang_old_path}: {e}", file=sys.stderr)
+                raise
+            except Exception as e:
+                print(f"Error: An unexpected error occurred while renaming {lang_old_path} to {lang_new_path}: {e}",
+                      file=sys.stderr)
+                raise
+
+    except Exception as e:
+        print(f"Error: An unexpected error occurred in rename_translations_files: {e}", file=sys.stderr)
+        raise
+
+
+def main():
+    args = parse_arguments()
+    if args.split:
+        if args.replace_underscore:
+            replace_underscores()
+        split_translation_files()
+    elif args.combine:
+        combine_translation_files()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Description
This pull request provides the CI scripts and developer tooling for the [Atlas Translations Management Design
](https://github.com/openedx/openedx-app-ios/blob/develop/docs/0002-atlas-translations-management.rst) proposal related to [OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).

### Testing instructions

#### Testing the `pull_translations`: 

```
make ATLAS_OPTIONS='--repository=Zeit-Labs/openedx-translations --revision=fc_55_sample' pull_translations
```

##### When the above command is executed:

1) The None-English translations will be pulled from openedx-translations repo into `I18N/` directory.
2) Then each language file will be split and distributed to the modules one by one
3) In the end, the pulled translations will be removed and only the split translations can be found in the modules' directories

##### If the script is working as intended:
1) The above command should not produce errors when executed.
2) The pulled translations should be correctly distributed among the modules in the expected paths.
3) The I18N directory should not exist after the script has been executed.
4) The app should have all its translations in place and can now be deployed.

#### Testing the `extract_translations`:

```
make extract_translations
```

##### When the above command is executed:

1) The English translations from all `en.lproj/Localizable.strings` files in all modules will be extracted
2) The keys of each translation entry will be updated to contain the name of the module followed by a dot e.g. `"Module_name.OLD_KEY_of_the_entry"`.
3) Then all of the updated entries will be put in one file: `I18N/en.lproj/Localizable.strings` 

##### If this script is working as intended:
1) The above command should not produce errors when executed.
2) Every entry from the English translation of each module should exist in `I18N/en.lproj/Localizable.strings` with the 3) corresponding comment, if present, placed before it.
3) The keys in I18N should contain the name of the module from which the entry originated, as specified.
4) The values and comments should be identical to the original ones.

### Status

We'll merge to this pull request into this branch multiple pull requests. We'll keep this open until we're ready for review.

This pull request is useful to watch progress.

### Q and A

#### 1. When are source strings extracted? what do the files look like?

  - An automated action will be developed to extract the English sources if they are changed in the IOS repo, then the action will push the sources to the translations repo.
  - The sources will be in one file: `I18N/en.lproj/Localizable.strings` and it will look like this:
```
"Module_one.FIRST.ENTRY.KEY.IN.MODULE.ONE" = "English Translation for the first entry in module one.";
"Module_one.SECOND.ENTRY.KEY.IN.MODULE.ONE" = "English Translation for the second entry in module one.";
.
.
"Module_two.FIRST.ENTRY.KEY.IN.MODULE.TWO" = "Translation for the first entry in module two";
.
.
```

#### 2. Does anything happen to those files before they are added to openedx-translations
The only extracted file is the English sources from the modules in the IOS repo as it is the only translation that lives in that repo. 
TBC

#### 3. When translation files are pulled via atlas what do the files look like?
When the translation files are pulled via atlas the files' structure is going to look like the structure below:
```
I18N/
----ar.lproj/
--------Localizable.strings
----uk.lproj/
--------Localizable.strings
----es.lproj/
--------Localizable.strings
```
As an example the es.lproj/Localiztion.strings would look like:
`I18N/es.lproj/Localizable.strings` 
```
"Module_one.FIRST.ENTRY.KEY.IN.MODULE.ONE" = "Traducción al inglés de la primera entrada del módulo uno.";
"Module_one.SECOND.ENTRY.KEY.IN.MODULE.ONE" = "Traducción al inglés de la segunda entrada del módulo uno.";
.
.
"Module_two.FIRST.ENTRY.KEY.IN.MODULE.TWO" = "Traducción de la primera entrada del módulo dos.";
.
.
```
#### 4) What is done to those files after `atlas pull` to make them work in the app build process?

After `atlas pull` is completed, all language translation files are retrieved, similar to the process described in the previous question. Subsequently, a Python script is executed to process each file. This script iterates through each translation file, splits it, removes the module name from the keys, and organizes each entry into its corresponding module.

For instance, the `I18N/es.lproj/Localizable.strings` file is split into two separate files:

1. `Module_one/Module_one/es.lproj/Localizable.strings`
2. `Module_two/Module_two/es.lproj/Localizable.strings`

Inside `Module_one/Module_one/es.lproj/Localizable.strings`, the content would resemble:
```
"FIRST.ENTRY.KEY.IN.MODULE.ONE" = "English translation of the first entry in module one.";
"SECOND.ENTRY.KEY.IN.MODULE.ONE" = "English translation of the second entry in module one.";
.
.
.
```

Similarly, inside `Module_two/Module_two/es.lproj/Localizable.strings`, it would appear as:
```
"FIRST.ENTRY.KEY.IN.MODULE.TWO" = "English translation of the first entry in module two.";
.
.
.
```

Once the Python script completes its task and the files are split, the make script proceeds to remove the entire `I18N` directory and its contents.

#### 5) Why is this needed?
This new process is being introduced to have the best combination of Developer Experience and Translator Experience.

The best experience for Translators requires combining source strings into as few transifex resources as possible. The best experience for Engineers requires splitting translation source files to fit within the modular architecture.

#### 6) What should live in [openedx translations](https://github.com/openedx/openedx-translations)?
Translations that were done by the open-edx translators are going to be stored in  [openedx translations](https://github.com/openedx/openedx-translations).

#### 7) What should live in atlas?
Atlas is the tool that we are using to pull the translations from [openedx translations](https://github.com/openedx/openedx-translations); therefor, no translations are stored in atlas.

#### 8) What should live in the [openedx-app-ios](https://github.com/openedx/openedx-app-ios) repo?
In the IOS app repo only the English sources are going to be stored.

### TODO

 - [x] Fix the `python3-localizable` pip package for python3 compatibility
 - [x] Install `openedx-atlas` in the virtual env
 - [x] Refactor the code into a single Python script to improve code reuse
 - [ ] Add CI scripts for `make extract_translations`
 - [ ] Test with the iOS team (Volo and others)
 - [x] Review by Brian Smith

### Related issues
 - Closes https://github.com/openedx/openedx-app-ios/issues/106