### PR TITLE
fix: build warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -24,8 +24,17 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Discovery/DiscoveryTests
   - Discussion/DiscussionTests
   - Profile/ProfileTests
+  - WhatsNew/WhatsNewTests
+  - Theme/ThemeTests
   - vendor
-#  - Source/ExcludedFolder
+  - Core/Core/SwiftGen
+  - Authorization/Authorization/SwiftGen
+  - Course/Course/SwiftGen
+  - Discovery/Discovery/SwiftGen
+  - Dashboard/Dashboard/SwiftGen
+  - Profile/Profile/SwiftGen
+  - WhatsNew/WhatsNew/SwiftGen
+  - Theme/Theme/SwiftGen
 #  - Source/ExcludedFile.swift
 #  - Source/*/ExcludedFile.swift # Exclude files with a wildcard
 #analyzer_rules: # Rules run by `swiftlint analyze` (experimental)

--- a/Authorization/Authorization/Presentation/AuthorizationAnalytics.swift
+++ b/Authorization/Authorization/Presentation/AuthorizationAnalytics.swift
@@ -22,10 +22,10 @@ public enum AuthMethod: Equatable {
 }
 
 public enum SocialAuthMethod: String {
-    case facebook = "facebook"
-    case google = "google"
-    case microsoft = "microsoft"
-    case apple = "apple"
+    case facebook
+    case google
+    case microsoft
+    case apple
 }
 
 //sourcery: AutoMockable

--- a/Core/Core/Extensions/DateExtension.swift
+++ b/Core/Core/Extensions/DateExtension.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-
 public extension Date {
     init(iso8601: String) {
         let formats = ["yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ"]

--- a/Core/Core/Extensions/Dictionary+JSON.swift
+++ b/Core/Core/Extensions/Dictionary+JSON.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public extension Dictionary where Key == String, Value == String {
-    public func toJson() -> String? {
+    func toJson() -> String? {
         guard let jsonData = try? JSONSerialization.data(withJSONObject: self, options: []) else {
             return nil
         }

--- a/Core/Core/Extensions/String+JSON.swift
+++ b/Core/Core/Extensions/String+JSON.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public extension String {
-    public func jsonStringToDictionary() -> [String: Any]? {
+    func jsonStringToDictionary() -> [String: Any]? {
         guard let jsonData = self.data(using: .utf8) else {
             return nil
         }

--- a/Core/Core/Extensions/ViewExtension.swift
+++ b/Core/Core/Extensions/ViewExtension.swift
@@ -154,7 +154,7 @@ public extension View {
                 .offset(y: 2)
                 .foregroundColor(color)
             self
-                .offset(y: 2)                
+                .offset(y: 2)
         }
     }
     

--- a/Core/Core/Network/DownloadManager.swift
+++ b/Core/Core/Network/DownloadManager.swift
@@ -551,6 +551,7 @@ public final class BackgroundTaskProvider {
 }
 
 // Mark - For testing and SwiftUI preview
+// swiftlint:disable file_length
 #if DEBUG
 public class DownloadManagerMock: DownloadManagerProtocol {
 
@@ -639,3 +640,4 @@ public class DownloadManagerMock: DownloadManagerProtocol {
 
 }
 #endif
+// swiftlint:enable file_length

--- a/Core/Core/Providers/SocialAuth/MicrosoftAuthProvider.swift
+++ b/Core/Core/Providers/SocialAuth/MicrosoftAuthProvider.swift
@@ -49,7 +49,7 @@ public final class MicrosoftAuthProvider {
                     continuation.resume(
                         returning: .success(
                             SocialAuthResponse(
-                                name: account.accountClaims?["name"] as? String ?? "" ,
+                                name: account.accountClaims?["name"] as? String ?? "",
                                 email: account.accountClaims?["email"] as? String ?? "",
                                 token: result.accessToken
                             )

--- a/Core/Core/View/Base/AppReview/ThirdPartyMailer/ThirdPartyMailClient.swift
+++ b/Core/Core/View/Base/AppReview/ThirdPartyMailer/ThirdPartyMailClient.swift
@@ -5,6 +5,8 @@
 //
 // Licensed under MIT License
 
+// swiftlint:disable all
+
 import SwiftUI
 
 /// A third-party mail client, offering a custom URL scheme.
@@ -145,3 +147,4 @@ public extension ThirdPartyMailClient {
         }
     }
 }
+// swiftlint:enable all

--- a/Core/Core/View/Base/RefreshableScrollView.swift
+++ b/Core/Core/View/Base/RefreshableScrollView.swift
@@ -282,7 +282,7 @@ public extension List {
                                                         onRefresh: @escaping OnRefresh,
                                                         @ViewBuilder progress:
                                                         @escaping RefreshProgressBuilder<Progress>) -> some View {
-        if #available(iOS 15.0, macOS 12.0, *) {
+        if #available(macOS 12.0, *) {
             self.refreshable {
                 await withCheckedContinuation { cont in
                     onRefresh {

--- a/Core/Core/View/Base/UnitButtonView.swift
+++ b/Core/Core/View/Base/UnitButtonView.swift
@@ -199,7 +199,8 @@ public struct UnitButtonView: View {
                                             miterLimit: 1
                                         ))
                                         .foregroundColor(
-                                            type == .continueLesson ? Theme.Colors.accentButtonColor 
+                                            type == .continueLesson
+                                            ? Theme.Colors.accentButtonColor
                                             : Theme.Colors.secondaryButtonBorderColor
                                         )
                                 )

--- a/Core/Core/View/Base/Webview/WebView.swift
+++ b/Core/Core/View/Base/Webview/WebView.swift
@@ -302,8 +302,8 @@ extension WKWebView {
 
 extension Array where Element == WebviewInjection {
     func handle(message: WKScriptMessage) {
-        let messages = compactMap{ $0.messages }
-            .flatMap{ $0 }
+        let messages = compactMap { $0.messages }
+            .flatMap { $0 }
         if let currentMessage = messages.first(where: { $0.name == message.name }) {
             currentMessage.handler(message.body, message.webView)
         }

--- a/Course/Course.xcodeproj/project.pbxproj
+++ b/Course/Course.xcodeproj/project.pbxproj
@@ -49,7 +49,6 @@
 		02F0144F28F46474002E513D /* CourseContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F0144E28F46474002E513D /* CourseContainerView.swift */; };
 		02F0145728F4A2FF002E513D /* CourseContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F0145628F4A2FF002E513D /* CourseContainerViewModel.swift */; };
 		02F066E829DC71750073E13B /* SubtittlesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F066E729DC71750073E13B /* SubtittlesView.swift */; };
-		02F175372A4DAFD20019CD70 /* CourseAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F175362A4DAFD20019CD70 /* CourseAnalytics.swift */; };
 		02F3BFDD29252E900051930C /* CourseRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F3BFDC29252E900051930C /* CourseRouter.swift */; };
 		02F78AEB29E6BCA20038DE30 /* VideoPlayerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F78AEA29E6BCA20038DE30 /* VideoPlayerViewModelTests.swift */; };
 		02F98A8128F8224200DE94C0 /* Discussion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02F98A8028F8224200DE94C0 /* Discussion.framework */; };
@@ -67,6 +66,7 @@
 		0766DFCC299AA7A600EBEF6A /* YouTubeVideoPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0766DFCB299AA7A600EBEF6A /* YouTubeVideoPlayer.swift */; };
 		0766DFCE299AB26D00EBEF6A /* EncodedVideoPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0766DFCD299AB26D00EBEF6A /* EncodedVideoPlayer.swift */; };
 		0766DFD0299AB29000EBEF6A /* PlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0766DFCF299AB29000EBEF6A /* PlayerViewController.swift */; };
+		07DE59862BECB868001CBFBC /* CourseAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07DE59852BECB868001CBFBC /* CourseAnalytics.swift */; };
 		197FB8EA8F92F00A8F383D82 /* Pods_App_Course.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5E795BD160CDA7D9C120DE6 /* Pods_App_Course.framework */; };
 		975F475E2B6151FD00E5B031 /* CourseDatesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 975F475D2B6151FD00E5B031 /* CourseDatesMock.swift */; };
 		975F47602B615DA700E5B031 /* CourseStructureMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 975F475F2B615DA700E5B031 /* CourseStructureMock.swift */; };
@@ -148,7 +148,6 @@
 		02F0144E28F46474002E513D /* CourseContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseContainerView.swift; sourceTree = "<group>"; };
 		02F0145628F4A2FF002E513D /* CourseContainerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseContainerViewModel.swift; sourceTree = "<group>"; };
 		02F066E729DC71750073E13B /* SubtittlesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtittlesView.swift; sourceTree = "<group>"; };
-		02F175362A4DAFD20019CD70 /* CourseAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CourseAnalytics.swift; path = ../Presentation/CourseAnalytics.swift; sourceTree = "<group>"; };
 		02F3BFDC29252E900051930C /* CourseRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseRouter.swift; sourceTree = "<group>"; };
 		02F78AEA29E6BCA20038DE30 /* VideoPlayerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = VideoPlayerViewModelTests.swift; path = CourseTests/Presentation/Unit/VideoPlayerViewModelTests.swift; sourceTree = SOURCE_ROOT; };
 		02F98A8028F8224200DE94C0 /* Discussion.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Discussion.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -166,6 +165,7 @@
 		0766DFCB299AA7A600EBEF6A /* YouTubeVideoPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeVideoPlayer.swift; sourceTree = "<group>"; };
 		0766DFCD299AB26D00EBEF6A /* EncodedVideoPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodedVideoPlayer.swift; sourceTree = "<group>"; };
 		0766DFCF299AB29000EBEF6A /* PlayerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerViewController.swift; sourceTree = "<group>"; };
+		07DE59852BECB868001CBFBC /* CourseAnalytics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseAnalytics.swift; sourceTree = "<group>"; };
 		2A444220A08C5035164B071F /* Pods-App-Course-CourseTests.releasedev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App-Course-CourseTests.releasedev.xcconfig"; path = "Target Support Files/Pods-App-Course-CourseTests/Pods-App-Course-CourseTests.releasedev.xcconfig"; sourceTree = "<group>"; };
 		3A55620C6018088BFF77F9AE /* Pods-App-CourseDetails.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App-CourseDetails.debug.xcconfig"; path = "Target Support Files/Pods-App-CourseDetails/Pods-App-CourseDetails.debug.xcconfig"; sourceTree = "<group>"; };
 		3D506212980347A9D5A70E20 /* Pods-App-Course.debugstage.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App-Course.debugstage.xcconfig"; path = "Target Support Files/Pods-App-Course/Pods-App-Course.debugstage.xcconfig"; sourceTree = "<group>"; };
@@ -294,7 +294,6 @@
 		0289F8F028E1C3510064F8F3 /* Course */ = {
 			isa = PBXGroup;
 			children = (
-				979A6AB92BC3FFF8001B0DE3 /* Analytics */,
 				02B6B3AD28E1C47100232911 /* SwiftGen */,
 				02B6B3B828E1D12900232911 /* Data */,
 				02B6B3B528E1D10700232911 /* Domain */,
@@ -397,6 +396,7 @@
 				BAC0E0DC2B32F0EA006B68A9 /* Downloads */,
 				BAD9CA482B2C88D500DE790A /* Subviews */,
 				02F3BFDC29252E900051930C /* CourseRouter.swift */,
+				07DE59852BECB868001CBFBC /* CourseAnalytics.swift */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -506,14 +506,6 @@
 				975F475F2B615DA700E5B031 /* CourseStructureMock.swift */,
 			);
 			path = Mock;
-			sourceTree = "<group>";
-		};
-		979A6AB92BC3FFF8001B0DE3 /* Analytics */ = {
-			isa = PBXGroup;
-			children = (
-				02F175362A4DAFD20019CD70 /* CourseAnalytics.swift */,
-			);
-			path = Analytics;
 			sourceTree = "<group>";
 		};
 		97CA95212B875EA200A9EDEA /* Views */ = {
@@ -892,6 +884,7 @@
 				BAC0E0DB2B32F0AE006B68A9 /* CourseVideoDownloadBarViewModel.swift in Sources */,
 				DB7D6EAE2ADFCB4A0036BB13 /* CourseDatesViewModel.swift in Sources */,
 				02F066E829DC71750073E13B /* SubtittlesView.swift in Sources */,
+				07DE59862BECB868001CBFBC /* CourseAnalytics.swift in Sources */,
 				022C64E229ADEB83000F532B /* CourseUpdate.swift in Sources */,
 				BA58CF642B471363005B102E /* VideoDownloadQualityContainerView.swift in Sources */,
 				BA58CF5D2B3D804D005B102E /* CourseStorage.swift in Sources */,
@@ -908,7 +901,6 @@
 				DB7D6EAC2ADFCAC50036BB13 /* CourseDatesView.swift in Sources */,
 				0766DFCC299AA7A600EBEF6A /* YouTubeVideoPlayer.swift in Sources */,
 				022F8E162A1DFBC6008EFAB9 /* YouTubeVideoPlayerViewModel.swift in Sources */,
-				02F175372A4DAFD20019CD70 /* CourseAnalytics.swift in Sources */,
 				02B6B3BE28E1D15C00232911 /* CourseEndpoint.swift in Sources */,
 				97EA4D862B85034D00663F58 /* CalendarManager.swift in Sources */,
 			);

--- a/Course/Course/Presentation/Dates/CourseDatesView.swift
+++ b/Course/Course/Presentation/Dates/CourseDatesView.swift
@@ -510,7 +510,7 @@ struct CourseDatesView_Previews: PreviewProvider {
         CourseDatesView(
             courseID: "",
             coordinate: .constant(0),
-            collapsed: .constant(false), 
+            collapsed: .constant(false),
             viewModel: viewModel)
     }
 }

--- a/Course/Course/Presentation/Outline/CourseOutlineView.swift
+++ b/Course/Course/Presentation/Outline/CourseOutlineView.swift
@@ -364,7 +364,7 @@ struct CourseOutlineView_Previews: PreviewProvider {
                 title: "Course title",
                 courseID: "",
                 isVideo: false,
-                selection: $selection, 
+                selection: $selection,
                 coordinate: .constant(0),
                 collapsed: .constant(false),
                 dateTabIndex: 2

--- a/Course/Course/Presentation/Unit/CourseNavigationView.swift
+++ b/Course/Course/Presentation/Unit/CourseNavigationView.swift
@@ -156,7 +156,7 @@ struct CourseNavigationView_Previews: PreviewProvider {
             chapterIndex: 1,
             sequentialIndex: 1,
             verticalIndex: 1,
-            interactor: CourseInteractor.mock, 
+            interactor: CourseInteractor.mock,
             config: ConfigMock(),
             router: CourseRouterMock(),
             analytics: CourseAnalyticsMock(),

--- a/Course/Course/Presentation/Video/SubtittlesView.swift
+++ b/Course/Course/Presentation/Video/SubtittlesView.swift
@@ -124,7 +124,7 @@ struct SubtittlesView_Previews: PreviewProvider {
                 blockID: "", courseID: "",
                 languages: [],
                 interactor: CourseInteractor(repository: CourseRepositoryMock()),
-                router: CourseRouterMock(), 
+                router: CourseRouterMock(),
                 appStorage: CoreStorageMock(),
                 connectivity: Connectivity()
             ), scrollTo: {_ in }

--- a/Course/Course/Presentation/Video/YouTubeVideoPlayer.swift
+++ b/Course/Course/Presentation/Video/YouTubeVideoPlayer.swift
@@ -59,7 +59,7 @@ public struct YouTubeVideoPlayer: View {
                             SubtittlesView(
                                 languages: viewModel.languages,
                                 currentTime: $viewModel.currentTime,
-                                viewModel: viewModel, 
+                                viewModel: viewModel,
                                 scrollTo: { date in
                                     viewModel.youtubePlayer.seek(
                                         to: Measurement(value: date.secondsSinceMidnight(), unit: UnitDuration.seconds),

--- a/Discussion/Discussion/Data/Network/DiscussionRepository.swift
+++ b/Discussion/Discussion/Data/Network/DiscussionRepository.swift
@@ -210,8 +210,8 @@ public class DiscussionRepository: DiscussionRepositoryProtocol {
 }
 
 // Mark - For testing and SwiftUI preview
-#if DEBUG
 // swiftlint:disable all
+#if DEBUG
 public class DiscussionRepositoryMock: DiscussionRepositoryProtocol {
 
     public func getCourseDiscussionInfo(courseID: String) async throws -> DiscussionInfo {
@@ -515,5 +515,5 @@ public class DiscussionRepositoryMock: DiscussionRepositoryProtocol {
         return stringJSON
     }    
 }
-// swiftlint:enable all
 #endif
+// swiftlint:enable all

--- a/Discussion/Discussion/Domain/Model/UserThread.swift
+++ b/Discussion/Discussion/Domain/Model/UserThread.swift
@@ -49,7 +49,7 @@ public struct UserThread {
         renderedBody: String,
         voted: Bool,
         voteCount: Int,
-        courseID: String, 
+        courseID: String,
         type: PostType,
         title: String,
         pinned: Bool,

--- a/Discussion/Discussion/Presentation/DiscussionTopics/DiscussionSearchTopicsViewModel.swift
+++ b/Discussion/Discussion/Presentation/DiscussionTopics/DiscussionSearchTopicsViewModel.swift
@@ -161,7 +161,7 @@ public class DiscussionSearchTopicsViewModel<S: Scheduler>: ObservableObject {
                 guard let self else { return }
                 self.router.showThread(
                     thread: thread,
-                    postStateSubject: self.postStateSubject, 
+                    postStateSubject: self.postStateSubject,
                     isBlackedOut: false,
                     animated: true
                 )

--- a/OpenEdX/Managers/AnalyticsManager/AnalyticsManager.swift
+++ b/OpenEdX/Managers/AnalyticsManager/AnalyticsManager.swift
@@ -21,6 +21,7 @@ protocol AnalyticsService {
     func logEvent(_ event: AnalyticsEvent, parameters: [String: Any]?)
 }
 
+// swiftlint:disable type_body_length file_length
 class AnalyticsManager: AuthorizationAnalytics,
                         MainScreenAnalytics,
                         DiscoveryAnalytics,
@@ -30,6 +31,7 @@ class AnalyticsManager: AuthorizationAnalytics,
                         DiscussionAnalytics,
                         CoreAnalytics,
                         WhatsNewAnalytics {
+    
     private var services: [AnalyticsService] = []
     
     // Init Analytics Manager
@@ -223,7 +225,7 @@ class AnalyticsManager: AuthorizationAnalytics,
             EventParamKey.name: EventBIValue.profileDeleteAccountClicked.rawValue,
             EventParamKey.category: EventCategory.profile
         ]
-        logEvent(.profileDeleteAccountClicked)
+        logEvent(.profileDeleteAccountClicked, parameters: parameters)
     }
     
     public func profileVideoSettingsClicked() {
@@ -329,9 +331,10 @@ class AnalyticsManager: AuthorizationAnalytics,
     public func userLogout(force: Bool) {
         let parameters = [
             EventParamKey.name: EventBIValue.userLogout.rawValue,
-            EventParamKey.category: EventCategory.profile
+            EventParamKey.category: EventCategory.profile,
+            EventParamKey.force: "\(force)"
         ]
-        logEvent(.userLogout, parameters: [EventParamKey.force: force])
+        logEvent(.userLogout, parameters: parameters)
     }
     
     // MARK: Course
@@ -779,3 +782,4 @@ class AnalyticsManager: AuthorizationAnalytics,
         logEvent(.whatnewClose, parameters: parameters)
     }
 }
+// swiftlint:enable type_body_length file_length

--- a/OpenEdX/Managers/PushNotificationsManager/Listeners/BrazeListener.swift
+++ b/OpenEdX/Managers/PushNotificationsManager/Listeners/BrazeListener.swift
@@ -10,8 +10,7 @@ import Foundation
 class BrazeListener: PushNotificationsListener {
     func shouldListenNotification(userinfo: [AnyHashable: Any]) -> Bool {
         //A push notification sent from the braze has a key ab in it like ab = {c = "c_value";};
-        guard let _ = userinfo["ab"] as? [String : Any], userinfo.count > 0
-        else { return false }
-        return true
+        let data = userinfo["ab"] as? [String: Any]
+        return userinfo.count > 0 && data != nil
     }
 }

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ use_frameworks! :linkage => :static
 abstract_target "App" do
   
   #Code style
-  pod 'SwiftLint', '~> 0.5'
+  pod 'SwiftLint', '~> 0.54.0'
   #CodeGen for resources
   pod 'SwiftGen', '~> 6.6'
   

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,8 +5,8 @@ PODS:
   - Sourcery (1.8.0):
     - Sourcery/CLI-Only (= 1.8.0)
   - Sourcery/CLI-Only (1.8.0)
-  - SwiftGen (6.6.2)
-  - SwiftLint (0.53.0)
+  - SwiftGen (6.6.3)
+  - SwiftLint (0.54.0)
   - SwiftUIIntrospect (0.12.0)
   - SwiftyMocky (4.2.0):
     - Sourcery (= 1.8.0)
@@ -17,7 +17,7 @@ DEPENDENCIES:
   - KeychainSwift (~> 20.0)
   - Kingfisher (~> 7.8)
   - SwiftGen (~> 6.6)
-  - SwiftLint (~> 0.5)
+  - SwiftLint (~> 0.54.0)
   - SwiftUIIntrospect (~> 0.8)
   - SwiftyMocky (from `https://github.com/MakeAWishFoundation/SwiftyMocky.git`, tag `4.2.0`)
   - Swinject (= 2.8.3)
@@ -48,12 +48,12 @@ SPEC CHECKSUMS:
   KeychainSwift: 0ce6a4d13f7228054d1a71bb1b500448fb2ab837
   Kingfisher: 1d14e9f59cbe19389f591c929000332bf70efd32
   Sourcery: 6f5fe49b82b7e02e8c65560cbd52e1be67a1af2e
-  SwiftGen: 1366a7f71aeef49954ca5a63ba4bef6b0f24138c
-  SwiftLint: 5ce4d6a8ff83f1b5fd5ad5dbf30965d35af65e44
+  SwiftGen: 4993cbf71cbc4886f775e26f8d5c3a1188ec9f99
+  SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   SwiftUIIntrospect: 89f443402f701a9197e9e54e3c2ed00b10c32e6d
   SwiftyMocky: c5e96e4ff76ec6dbf5a5941aeb039b5a546954a0
   Swinject: 893c9a543000ac2f10ee4cbaf0933c6992c935d5
 
-PODFILE CHECKSUM: 881176d00eabfe8f78d6022c56c277cf61aad22b
+PODFILE CHECKSUM: 1b95af9ed204a9f360c00f6f9afa9955ad03b540
 
 COCOAPODS: 1.15.2

--- a/Profile/Profile/Presentation/EditProfile/EditProfileViewModel.swift
+++ b/Profile/Profile/Presentation/EditProfile/EditProfileViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import Core
 import SwiftUI
 
-// swiftlint:disable file_length type_body_length
+// swiftlint:disable type_body_length
 public struct Changes: Equatable {
     public var shortBiography: String
     public var profileType: ProfileType
@@ -141,14 +141,17 @@ public class EditProfileViewModel: ObservableObject {
     
     func checkChanges() {
         withAnimation(.easeIn(duration: 0.1)) {
-            self.isChanged =
-            [spokenLanguageConfiguration.text.isEmpty ? false : spokenLanguageConfiguration.text != userModel.spokenLanguage,
-             yearsConfiguration.text.isEmpty ? false : yearsConfiguration.text != String(userModel.yearOfBirth),
-             countriesConfiguration.text.isEmpty ? false : countriesConfiguration.text != userModel.country,
-             userModel.shortBiography != profileChanges.shortBiography,
-             profileChanges.isAvatarChanged,
-             profileChanges.isAvatarDeleted,
-             userModel.isFullProfile != profileChanges.profileType.boolValue].contains(where: { $0 == true })
+            self.isChanged = [
+                spokenLanguageConfiguration.text.isEmpty
+                ? false
+                : spokenLanguageConfiguration.text != userModel.spokenLanguage,
+                yearsConfiguration.text.isEmpty ? false : yearsConfiguration.text != String(userModel.yearOfBirth),
+                countriesConfiguration.text.isEmpty ? false : countriesConfiguration.text != userModel.country,
+                userModel.shortBiography != profileChanges.shortBiography,
+                profileChanges.isAvatarChanged,
+                profileChanges.isAvatarDeleted,
+                userModel.isFullProfile != profileChanges.profileType.boolValue
+            ].contains(where: { $0 == true })
         }
     }
     
@@ -365,4 +368,4 @@ public class EditProfileViewModel: ObservableObject {
         analytics.profileEditDoneClicked()
     }
 }
-// swiftlint:enable file_length type_body_length
+// swiftlint:enable type_body_length

--- a/Theme/Theme/Theme.swift
+++ b/Theme/Theme/Theme.swift
@@ -12,6 +12,7 @@ private var fontsParser = FontParser()
 
 public struct Theme {
     
+    // swiftlint:disable line_length
     public struct Colors {
         public private(set) static var accentColor = ThemeAssets.accentColor.swiftUIColor
         public private(set) static var accentXColor = ThemeAssets.accentXColor.swiftUIColor
@@ -163,6 +164,7 @@ public struct Theme {
             self.irreversibleAlert = irreversibleAlert
         }
     }
+    // swiftlint:enable line_length
     
     // Use this structure where the computed Color.uiColor() extension is not appropriate.
     public struct UIColors {


### PR DESCRIPTION
This pull request updates the Swiftlint version and addresses a bunch of warnings. 
| Before | After |
|----------|----------|
| <img width="64" alt="Screenshot 2024-05-09 at 11 31 39" src="https://github.com/openedx/openedx-app-ios/assets/127732735/b136f6a7-9107-485a-adc0-d46f7bd7edfd"> | <img width="64" alt="Screenshot 2024-05-09 at 11 34 38" src="https://github.com/openedx/openedx-app-ios/assets/127732735/5666e110-216e-4a81-983a-e6cab2f9cd9a"> |

Fixed:
- Trailing Whitespace Violation
- Line Length Violation
- Generated and third-party files excluded from linting