### PR TITLE
fix: discovery enabled by default

### DIFF
--- a/Core/Core/Configuration/Config/DiscoveryConfig.swift
+++ b/Core/Core/Configuration/Config/DiscoveryConfig.swift
@@ -40,7 +40,7 @@ public class DiscoveryConfig: NSObject {
     init(dictionary: [String: AnyObject]) {
         type = (dictionary[DiscoveryKeys.discoveryType] as? String).flatMap {
             DiscoveryConfigType(rawValue: $0)
-        } ?? .none
+        } ?? .native
         webview = DiscoveryWebviewConfig(dictionary: dictionary[DiscoveryKeys.webview] as? [String: AnyObject] ?? [:])
     }
     


### PR DESCRIPTION
Fixed discovery configuration to enable it by default for the Open edX app.