### PR TITLE
fix: RTL arrowLeft in core assets

### DIFF
--- a/Core/Core/Assets.xcassets/arrowLeft.imageset/Contents.json
+++ b/Core/Core/Assets.xcassets/arrowLeft.imageset/Contents.json
@@ -2,7 +2,8 @@
   "images" : [
     {
       "filename" : "icon left.svg",
-      "idiom" : "universal"
+      "idiom" : "universal",
+      "language-direction" : "left-to-right"
     },
     {
       "appearances" : [
@@ -12,7 +13,8 @@
         }
       ],
       "filename" : "icon left-2.svg",
-      "idiom" : "universal"
+      "idiom" : "universal",
+      "language-direction" : "left-to-right"
     }
   ],
   "info" : {


### PR DESCRIPTION
### New contributor
I'm Rawan Matar, from ZeitLabs.
I start working on supporting RTL in OpenEdx iOS app, and this is the first change in my plan.

### Description
changed the direction attribute of the "arrowLeft" image in Core/Assets.

### Screenshots
| Before | After |
|--------|-------|
| ![IMG_3090](https://github.com/openedx/openedx-app-ios/assets/41669180/a1bbc540-d9d2-426f-871a-bb6b1f49d3b6)| ![IMG_3087](https://github.com/openedx/openedx-app-ios/assets/41669180/3a25a23b-3e44-4e06-9b84-b278cd1f8735)|

