### PR TITLE
feat: Delete old downloaded videos data on device to optimize storage

### DIFF
--- a/Authorization/AuthorizationTests/AuthorizationMock.generated.swift
+++ b/Authorization/AuthorizationTests/AuthorizationMock.generated.swift
@@ -2405,6 +2405,12 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 		return __value
     }
 
+    open func removeAppSupportDirectoryDeprecatedContent() {
+        addInvocation(.m_removeAppSupportDirectoryDeprecatedContent)
+		let perform = methodPerformValue(.m_removeAppSupportDirectoryDeprecatedContent) as? () -> Void
+		perform?()
+    }
+
 
     fileprivate enum MethodType {
         case m_publisher
@@ -2421,6 +2427,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         case m_fileUrl__for_blockId(Parameter<String>)
         case m_resumeDownloading
         case m_isLargeVideosSize__blocks_blocks(Parameter<[CourseBlock]>)
+        case m_removeAppSupportDirectoryDeprecatedContent
         case p_currentDownloadTask_get
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
@@ -2477,6 +2484,8 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsBlocks, rhs: rhsBlocks, with: matcher), lhsBlocks, rhsBlocks, "blocks"))
 				return Matcher.ComparisonResult(results)
+
+            case (.m_removeAppSupportDirectoryDeprecatedContent, .m_removeAppSupportDirectoryDeprecatedContent): return .match
             case (.p_currentDownloadTask_get,.p_currentDownloadTask_get): return Matcher.ComparisonResult.match
             default: return .none
             }
@@ -2498,6 +2507,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case let .m_fileUrl__for_blockId(p0): return p0.intValue
             case .m_resumeDownloading: return 0
             case let .m_isLargeVideosSize__blocks_blocks(p0): return p0.intValue
+            case .m_removeAppSupportDirectoryDeprecatedContent: return 0
             case .p_currentDownloadTask_get: return 0
             }
         }
@@ -2517,6 +2527,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case .m_fileUrl__for_blockId: return ".fileUrl(for:)"
             case .m_resumeDownloading: return ".resumeDownloading()"
             case .m_isLargeVideosSize__blocks_blocks: return ".isLargeVideosSize(blocks:)"
+            case .m_removeAppSupportDirectoryDeprecatedContent: return ".removeAppSupportDirectoryDeprecatedContent()"
             case .p_currentDownloadTask_get: return "[get] .currentDownloadTask"
             }
         }
@@ -2673,6 +2684,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         public static func fileUrl(for blockId: Parameter<String>) -> Verify { return Verify(method: .m_fileUrl__for_blockId(`blockId`))}
         public static func resumeDownloading() -> Verify { return Verify(method: .m_resumeDownloading)}
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>) -> Verify { return Verify(method: .m_isLargeVideosSize__blocks_blocks(`blocks`))}
+        public static func removeAppSupportDirectoryDeprecatedContent() -> Verify { return Verify(method: .m_removeAppSupportDirectoryDeprecatedContent)}
         public static var currentDownloadTask: Verify { return Verify(method: .p_currentDownloadTask_get) }
     }
 
@@ -2721,6 +2733,9 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         }
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>, perform: @escaping ([CourseBlock]) -> Void) -> Perform {
             return Perform(method: .m_isLargeVideosSize__blocks_blocks(`blocks`), performs: perform)
+        }
+        public static func removeAppSupportDirectoryDeprecatedContent(perform: @escaping () -> Void) -> Perform {
+            return Perform(method: .m_removeAppSupportDirectoryDeprecatedContent, performs: perform)
         }
     }
 

--- a/Authorization/AuthorizationTests/AuthorizationMock.generated.swift
+++ b/Authorization/AuthorizationTests/AuthorizationMock.generated.swift
@@ -2405,9 +2405,9 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 		return __value
     }
 
-    open func removeAppSupportDirectoryDeprecatedContent() {
-        addInvocation(.m_removeAppSupportDirectoryDeprecatedContent)
-		let perform = methodPerformValue(.m_removeAppSupportDirectoryDeprecatedContent) as? () -> Void
+    open func removeAppSupportDirectoryUnusedContent() {
+        addInvocation(.m_removeAppSupportDirectoryUnusedContent)
+		let perform = methodPerformValue(.m_removeAppSupportDirectoryUnusedContent) as? () -> Void
 		perform?()
     }
 
@@ -2427,7 +2427,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         case m_fileUrl__for_blockId(Parameter<String>)
         case m_resumeDownloading
         case m_isLargeVideosSize__blocks_blocks(Parameter<[CourseBlock]>)
-        case m_removeAppSupportDirectoryDeprecatedContent
+        case m_removeAppSupportDirectoryUnusedContent
         case p_currentDownloadTask_get
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
@@ -2485,7 +2485,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsBlocks, rhs: rhsBlocks, with: matcher), lhsBlocks, rhsBlocks, "blocks"))
 				return Matcher.ComparisonResult(results)
 
-            case (.m_removeAppSupportDirectoryDeprecatedContent, .m_removeAppSupportDirectoryDeprecatedContent): return .match
+            case (.m_removeAppSupportDirectoryUnusedContent, .m_removeAppSupportDirectoryUnusedContent): return .match
             case (.p_currentDownloadTask_get,.p_currentDownloadTask_get): return Matcher.ComparisonResult.match
             default: return .none
             }
@@ -2507,7 +2507,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case let .m_fileUrl__for_blockId(p0): return p0.intValue
             case .m_resumeDownloading: return 0
             case let .m_isLargeVideosSize__blocks_blocks(p0): return p0.intValue
-            case .m_removeAppSupportDirectoryDeprecatedContent: return 0
+            case .m_removeAppSupportDirectoryUnusedContent: return 0
             case .p_currentDownloadTask_get: return 0
             }
         }
@@ -2527,7 +2527,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case .m_fileUrl__for_blockId: return ".fileUrl(for:)"
             case .m_resumeDownloading: return ".resumeDownloading()"
             case .m_isLargeVideosSize__blocks_blocks: return ".isLargeVideosSize(blocks:)"
-            case .m_removeAppSupportDirectoryDeprecatedContent: return ".removeAppSupportDirectoryDeprecatedContent()"
+            case .m_removeAppSupportDirectoryUnusedContent: return ".removeAppSupportDirectoryUnusedContent()"
             case .p_currentDownloadTask_get: return "[get] .currentDownloadTask"
             }
         }
@@ -2684,7 +2684,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         public static func fileUrl(for blockId: Parameter<String>) -> Verify { return Verify(method: .m_fileUrl__for_blockId(`blockId`))}
         public static func resumeDownloading() -> Verify { return Verify(method: .m_resumeDownloading)}
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>) -> Verify { return Verify(method: .m_isLargeVideosSize__blocks_blocks(`blocks`))}
-        public static func removeAppSupportDirectoryDeprecatedContent() -> Verify { return Verify(method: .m_removeAppSupportDirectoryDeprecatedContent)}
+        public static func removeAppSupportDirectoryUnusedContent() -> Verify { return Verify(method: .m_removeAppSupportDirectoryUnusedContent)}
         public static var currentDownloadTask: Verify { return Verify(method: .p_currentDownloadTask_get) }
     }
 
@@ -2734,8 +2734,8 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>, perform: @escaping ([CourseBlock]) -> Void) -> Perform {
             return Perform(method: .m_isLargeVideosSize__blocks_blocks(`blocks`), performs: perform)
         }
-        public static func removeAppSupportDirectoryDeprecatedContent(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeAppSupportDirectoryDeprecatedContent, performs: perform)
+        public static func removeAppSupportDirectoryUnusedContent(perform: @escaping () -> Void) -> Perform {
+            return Perform(method: .m_removeAppSupportDirectoryUnusedContent, performs: perform)
         }
     }
 

--- a/Core/Core/Data/CoreStorage.swift
+++ b/Core/Core/Data/CoreStorage.swift
@@ -17,6 +17,7 @@ public protocol CoreStorage {
     var lastReviewDate: Date? {get set}
     var user: DataLayer.User? {get set}
     var userSettings: UserSettings? {get set}
+    var resetAppSupportDirectoryUserData: Bool? {get set}
     func clear()
 }
 
@@ -31,6 +32,7 @@ public class CoreStorageMock: CoreStorage {
     public var lastReviewDate: Date?
     public var user: DataLayer.User?
     public var userSettings: UserSettings?
+    public var resetAppSupportDirectoryUserData: Bool?
     public func clear() {}
     
     public init() {}

--- a/Core/Core/Network/DownloadManager.swift
+++ b/Core/Core/Network/DownloadManager.swift
@@ -125,7 +125,7 @@ public protocol DownloadManagerProtocol {
     func fileUrl(for blockId: String) -> URL?
     func isLargeVideosSize(blocks: [CourseBlock]) -> Bool
     
-    func removeAppSupportDirectoryDeprecatedContent()
+    func removeAppSupportDirectoryUnusedContent()
 }
 
 public enum DownloadManagerEvent {
@@ -473,7 +473,7 @@ public class DownloadManager: DownloadManagerProtocol {
         }
     }
     
-    public func removeAppSupportDirectoryDeprecatedContent() {
+    public func removeAppSupportDirectoryUnusedContent() {
         deleteMD5HashedFolders()
     }
     
@@ -488,7 +488,7 @@ public class DownloadManager: DownloadManagerProtocol {
             )
             return appSupportDirectory
         } catch {
-            print("Error getting Application Support Directory: \(error)")
+            debugPrint("Error getting Application Support Directory: \(error)")
             return nil
         }
     }
@@ -516,14 +516,14 @@ public class DownloadManager: DownloadManagerProtocol {
                 if isMD5Hash(folderName) {
                     do {
                         try fileManager.removeItem(at: folderURL)
-                        print("Deleted folder: \(folderName)")
+                        debugPrint("Deleted folder: \(folderName)")
                     } catch {
-                        print("Error deleting folder \(folderName): \(error)")
+                        debugPrint("Error deleting folder \(folderName): \(error)")
                     }
                 }
             }
         } catch {
-            print("Error reading contents of Application Support directory: \(error)")
+            debugPrint("Error reading contents of Application Support directory: \(error)")
         }
     }
 }
@@ -694,7 +694,7 @@ public class DownloadManagerMock: DownloadManagerProtocol {
         false
     }
 
-    public func removeAppSupportDirectoryDeprecatedContent() {
+    public func removeAppSupportDirectoryUnusedContent() {
         
     }
 }

--- a/Course/CourseTests/CourseMock.generated.swift
+++ b/Course/CourseTests/CourseMock.generated.swift
@@ -2831,6 +2831,12 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 		return __value
     }
 
+    open func removeAppSupportDirectoryDeprecatedContent() {
+        addInvocation(.m_removeAppSupportDirectoryDeprecatedContent)
+		let perform = methodPerformValue(.m_removeAppSupportDirectoryDeprecatedContent) as? () -> Void
+		perform?()
+    }
+
 
     fileprivate enum MethodType {
         case m_publisher
@@ -2847,6 +2853,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         case m_fileUrl__for_blockId(Parameter<String>)
         case m_resumeDownloading
         case m_isLargeVideosSize__blocks_blocks(Parameter<[CourseBlock]>)
+        case m_removeAppSupportDirectoryDeprecatedContent
         case p_currentDownloadTask_get
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
@@ -2903,6 +2910,8 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsBlocks, rhs: rhsBlocks, with: matcher), lhsBlocks, rhsBlocks, "blocks"))
 				return Matcher.ComparisonResult(results)
+
+            case (.m_removeAppSupportDirectoryDeprecatedContent, .m_removeAppSupportDirectoryDeprecatedContent): return .match
             case (.p_currentDownloadTask_get,.p_currentDownloadTask_get): return Matcher.ComparisonResult.match
             default: return .none
             }
@@ -2924,6 +2933,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case let .m_fileUrl__for_blockId(p0): return p0.intValue
             case .m_resumeDownloading: return 0
             case let .m_isLargeVideosSize__blocks_blocks(p0): return p0.intValue
+            case .m_removeAppSupportDirectoryDeprecatedContent: return 0
             case .p_currentDownloadTask_get: return 0
             }
         }
@@ -2943,6 +2953,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case .m_fileUrl__for_blockId: return ".fileUrl(for:)"
             case .m_resumeDownloading: return ".resumeDownloading()"
             case .m_isLargeVideosSize__blocks_blocks: return ".isLargeVideosSize(blocks:)"
+            case .m_removeAppSupportDirectoryDeprecatedContent: return ".removeAppSupportDirectoryDeprecatedContent()"
             case .p_currentDownloadTask_get: return "[get] .currentDownloadTask"
             }
         }
@@ -3099,6 +3110,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         public static func fileUrl(for blockId: Parameter<String>) -> Verify { return Verify(method: .m_fileUrl__for_blockId(`blockId`))}
         public static func resumeDownloading() -> Verify { return Verify(method: .m_resumeDownloading)}
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>) -> Verify { return Verify(method: .m_isLargeVideosSize__blocks_blocks(`blocks`))}
+        public static func removeAppSupportDirectoryDeprecatedContent() -> Verify { return Verify(method: .m_removeAppSupportDirectoryDeprecatedContent)}
         public static var currentDownloadTask: Verify { return Verify(method: .p_currentDownloadTask_get) }
     }
 
@@ -3147,6 +3159,9 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         }
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>, perform: @escaping ([CourseBlock]) -> Void) -> Perform {
             return Perform(method: .m_isLargeVideosSize__blocks_blocks(`blocks`), performs: perform)
+        }
+        public static func removeAppSupportDirectoryDeprecatedContent(perform: @escaping () -> Void) -> Perform {
+            return Perform(method: .m_removeAppSupportDirectoryDeprecatedContent, performs: perform)
         }
     }
 

--- a/Course/CourseTests/CourseMock.generated.swift
+++ b/Course/CourseTests/CourseMock.generated.swift
@@ -2831,9 +2831,9 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 		return __value
     }
 
-    open func removeAppSupportDirectoryDeprecatedContent() {
-        addInvocation(.m_removeAppSupportDirectoryDeprecatedContent)
-		let perform = methodPerformValue(.m_removeAppSupportDirectoryDeprecatedContent) as? () -> Void
+    open func removeAppSupportDirectoryUnusedContent() {
+        addInvocation(.m_removeAppSupportDirectoryUnusedContent)
+		let perform = methodPerformValue(.m_removeAppSupportDirectoryUnusedContent) as? () -> Void
 		perform?()
     }
 
@@ -2853,7 +2853,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         case m_fileUrl__for_blockId(Parameter<String>)
         case m_resumeDownloading
         case m_isLargeVideosSize__blocks_blocks(Parameter<[CourseBlock]>)
-        case m_removeAppSupportDirectoryDeprecatedContent
+        case m_removeAppSupportDirectoryUnusedContent
         case p_currentDownloadTask_get
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
@@ -2911,7 +2911,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsBlocks, rhs: rhsBlocks, with: matcher), lhsBlocks, rhsBlocks, "blocks"))
 				return Matcher.ComparisonResult(results)
 
-            case (.m_removeAppSupportDirectoryDeprecatedContent, .m_removeAppSupportDirectoryDeprecatedContent): return .match
+            case (.m_removeAppSupportDirectoryUnusedContent, .m_removeAppSupportDirectoryUnusedContent): return .match
             case (.p_currentDownloadTask_get,.p_currentDownloadTask_get): return Matcher.ComparisonResult.match
             default: return .none
             }
@@ -2933,7 +2933,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case let .m_fileUrl__for_blockId(p0): return p0.intValue
             case .m_resumeDownloading: return 0
             case let .m_isLargeVideosSize__blocks_blocks(p0): return p0.intValue
-            case .m_removeAppSupportDirectoryDeprecatedContent: return 0
+            case .m_removeAppSupportDirectoryUnusedContent: return 0
             case .p_currentDownloadTask_get: return 0
             }
         }
@@ -2953,7 +2953,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case .m_fileUrl__for_blockId: return ".fileUrl(for:)"
             case .m_resumeDownloading: return ".resumeDownloading()"
             case .m_isLargeVideosSize__blocks_blocks: return ".isLargeVideosSize(blocks:)"
-            case .m_removeAppSupportDirectoryDeprecatedContent: return ".removeAppSupportDirectoryDeprecatedContent()"
+            case .m_removeAppSupportDirectoryUnusedContent: return ".removeAppSupportDirectoryUnusedContent()"
             case .p_currentDownloadTask_get: return "[get] .currentDownloadTask"
             }
         }
@@ -3110,7 +3110,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         public static func fileUrl(for blockId: Parameter<String>) -> Verify { return Verify(method: .m_fileUrl__for_blockId(`blockId`))}
         public static func resumeDownloading() -> Verify { return Verify(method: .m_resumeDownloading)}
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>) -> Verify { return Verify(method: .m_isLargeVideosSize__blocks_blocks(`blocks`))}
-        public static func removeAppSupportDirectoryDeprecatedContent() -> Verify { return Verify(method: .m_removeAppSupportDirectoryDeprecatedContent)}
+        public static func removeAppSupportDirectoryUnusedContent() -> Verify { return Verify(method: .m_removeAppSupportDirectoryUnusedContent)}
         public static var currentDownloadTask: Verify { return Verify(method: .p_currentDownloadTask_get) }
     }
 
@@ -3160,8 +3160,8 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>, perform: @escaping ([CourseBlock]) -> Void) -> Perform {
             return Perform(method: .m_isLargeVideosSize__blocks_blocks(`blocks`), performs: perform)
         }
-        public static func removeAppSupportDirectoryDeprecatedContent(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeAppSupportDirectoryDeprecatedContent, performs: perform)
+        public static func removeAppSupportDirectoryUnusedContent(perform: @escaping () -> Void) -> Perform {
+            return Perform(method: .m_removeAppSupportDirectoryUnusedContent, performs: perform)
         }
     }
 

--- a/Dashboard/DashboardTests/DashboardMock.generated.swift
+++ b/Dashboard/DashboardTests/DashboardMock.generated.swift
@@ -2144,9 +2144,9 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 		return __value
     }
 
-    open func removeAppSupportDirectoryDeprecatedContent() {
-        addInvocation(.m_removeAppSupportDirectoryDeprecatedContent)
-		let perform = methodPerformValue(.m_removeAppSupportDirectoryDeprecatedContent) as? () -> Void
+    open func removeAppSupportDirectoryUnusedContent() {
+        addInvocation(.m_removeAppSupportDirectoryUnusedContent)
+		let perform = methodPerformValue(.m_removeAppSupportDirectoryUnusedContent) as? () -> Void
 		perform?()
     }
 
@@ -2166,7 +2166,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         case m_fileUrl__for_blockId(Parameter<String>)
         case m_resumeDownloading
         case m_isLargeVideosSize__blocks_blocks(Parameter<[CourseBlock]>)
-        case m_removeAppSupportDirectoryDeprecatedContent
+        case m_removeAppSupportDirectoryUnusedContent
         case p_currentDownloadTask_get
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
@@ -2224,7 +2224,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsBlocks, rhs: rhsBlocks, with: matcher), lhsBlocks, rhsBlocks, "blocks"))
 				return Matcher.ComparisonResult(results)
 
-            case (.m_removeAppSupportDirectoryDeprecatedContent, .m_removeAppSupportDirectoryDeprecatedContent): return .match
+            case (.m_removeAppSupportDirectoryUnusedContent, .m_removeAppSupportDirectoryUnusedContent): return .match
             case (.p_currentDownloadTask_get,.p_currentDownloadTask_get): return Matcher.ComparisonResult.match
             default: return .none
             }
@@ -2246,7 +2246,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case let .m_fileUrl__for_blockId(p0): return p0.intValue
             case .m_resumeDownloading: return 0
             case let .m_isLargeVideosSize__blocks_blocks(p0): return p0.intValue
-            case .m_removeAppSupportDirectoryDeprecatedContent: return 0
+            case .m_removeAppSupportDirectoryUnusedContent: return 0
             case .p_currentDownloadTask_get: return 0
             }
         }
@@ -2266,7 +2266,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case .m_fileUrl__for_blockId: return ".fileUrl(for:)"
             case .m_resumeDownloading: return ".resumeDownloading()"
             case .m_isLargeVideosSize__blocks_blocks: return ".isLargeVideosSize(blocks:)"
-            case .m_removeAppSupportDirectoryDeprecatedContent: return ".removeAppSupportDirectoryDeprecatedContent()"
+            case .m_removeAppSupportDirectoryUnusedContent: return ".removeAppSupportDirectoryUnusedContent()"
             case .p_currentDownloadTask_get: return "[get] .currentDownloadTask"
             }
         }
@@ -2423,7 +2423,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         public static func fileUrl(for blockId: Parameter<String>) -> Verify { return Verify(method: .m_fileUrl__for_blockId(`blockId`))}
         public static func resumeDownloading() -> Verify { return Verify(method: .m_resumeDownloading)}
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>) -> Verify { return Verify(method: .m_isLargeVideosSize__blocks_blocks(`blocks`))}
-        public static func removeAppSupportDirectoryDeprecatedContent() -> Verify { return Verify(method: .m_removeAppSupportDirectoryDeprecatedContent)}
+        public static func removeAppSupportDirectoryUnusedContent() -> Verify { return Verify(method: .m_removeAppSupportDirectoryUnusedContent)}
         public static var currentDownloadTask: Verify { return Verify(method: .p_currentDownloadTask_get) }
     }
 
@@ -2473,8 +2473,8 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>, perform: @escaping ([CourseBlock]) -> Void) -> Perform {
             return Perform(method: .m_isLargeVideosSize__blocks_blocks(`blocks`), performs: perform)
         }
-        public static func removeAppSupportDirectoryDeprecatedContent(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeAppSupportDirectoryDeprecatedContent, performs: perform)
+        public static func removeAppSupportDirectoryUnusedContent(perform: @escaping () -> Void) -> Perform {
+            return Perform(method: .m_removeAppSupportDirectoryUnusedContent, performs: perform)
         }
     }
 

--- a/Dashboard/DashboardTests/DashboardMock.generated.swift
+++ b/Dashboard/DashboardTests/DashboardMock.generated.swift
@@ -2144,6 +2144,12 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 		return __value
     }
 
+    open func removeAppSupportDirectoryDeprecatedContent() {
+        addInvocation(.m_removeAppSupportDirectoryDeprecatedContent)
+		let perform = methodPerformValue(.m_removeAppSupportDirectoryDeprecatedContent) as? () -> Void
+		perform?()
+    }
+
 
     fileprivate enum MethodType {
         case m_publisher
@@ -2160,6 +2166,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         case m_fileUrl__for_blockId(Parameter<String>)
         case m_resumeDownloading
         case m_isLargeVideosSize__blocks_blocks(Parameter<[CourseBlock]>)
+        case m_removeAppSupportDirectoryDeprecatedContent
         case p_currentDownloadTask_get
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
@@ -2216,6 +2223,8 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsBlocks, rhs: rhsBlocks, with: matcher), lhsBlocks, rhsBlocks, "blocks"))
 				return Matcher.ComparisonResult(results)
+
+            case (.m_removeAppSupportDirectoryDeprecatedContent, .m_removeAppSupportDirectoryDeprecatedContent): return .match
             case (.p_currentDownloadTask_get,.p_currentDownloadTask_get): return Matcher.ComparisonResult.match
             default: return .none
             }
@@ -2237,6 +2246,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case let .m_fileUrl__for_blockId(p0): return p0.intValue
             case .m_resumeDownloading: return 0
             case let .m_isLargeVideosSize__blocks_blocks(p0): return p0.intValue
+            case .m_removeAppSupportDirectoryDeprecatedContent: return 0
             case .p_currentDownloadTask_get: return 0
             }
         }
@@ -2256,6 +2266,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case .m_fileUrl__for_blockId: return ".fileUrl(for:)"
             case .m_resumeDownloading: return ".resumeDownloading()"
             case .m_isLargeVideosSize__blocks_blocks: return ".isLargeVideosSize(blocks:)"
+            case .m_removeAppSupportDirectoryDeprecatedContent: return ".removeAppSupportDirectoryDeprecatedContent()"
             case .p_currentDownloadTask_get: return "[get] .currentDownloadTask"
             }
         }
@@ -2412,6 +2423,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         public static func fileUrl(for blockId: Parameter<String>) -> Verify { return Verify(method: .m_fileUrl__for_blockId(`blockId`))}
         public static func resumeDownloading() -> Verify { return Verify(method: .m_resumeDownloading)}
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>) -> Verify { return Verify(method: .m_isLargeVideosSize__blocks_blocks(`blocks`))}
+        public static func removeAppSupportDirectoryDeprecatedContent() -> Verify { return Verify(method: .m_removeAppSupportDirectoryDeprecatedContent)}
         public static var currentDownloadTask: Verify { return Verify(method: .p_currentDownloadTask_get) }
     }
 
@@ -2460,6 +2472,9 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         }
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>, perform: @escaping ([CourseBlock]) -> Void) -> Perform {
             return Perform(method: .m_isLargeVideosSize__blocks_blocks(`blocks`), performs: perform)
+        }
+        public static func removeAppSupportDirectoryDeprecatedContent(perform: @escaping () -> Void) -> Perform {
+            return Perform(method: .m_removeAppSupportDirectoryDeprecatedContent, performs: perform)
         }
     }
 

--- a/Discovery/DiscoveryTests/DiscoveryMock.generated.swift
+++ b/Discovery/DiscoveryTests/DiscoveryMock.generated.swift
@@ -2338,9 +2338,9 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 		return __value
     }
 
-    open func removeAppSupportDirectoryDeprecatedContent() {
-        addInvocation(.m_removeAppSupportDirectoryDeprecatedContent)
-		let perform = methodPerformValue(.m_removeAppSupportDirectoryDeprecatedContent) as? () -> Void
+    open func removeAppSupportDirectoryUnusedContent() {
+        addInvocation(.m_removeAppSupportDirectoryUnusedContent)
+		let perform = methodPerformValue(.m_removeAppSupportDirectoryUnusedContent) as? () -> Void
 		perform?()
     }
 
@@ -2360,7 +2360,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         case m_fileUrl__for_blockId(Parameter<String>)
         case m_resumeDownloading
         case m_isLargeVideosSize__blocks_blocks(Parameter<[CourseBlock]>)
-        case m_removeAppSupportDirectoryDeprecatedContent
+        case m_removeAppSupportDirectoryUnusedContent
         case p_currentDownloadTask_get
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
@@ -2418,7 +2418,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsBlocks, rhs: rhsBlocks, with: matcher), lhsBlocks, rhsBlocks, "blocks"))
 				return Matcher.ComparisonResult(results)
 
-            case (.m_removeAppSupportDirectoryDeprecatedContent, .m_removeAppSupportDirectoryDeprecatedContent): return .match
+            case (.m_removeAppSupportDirectoryUnusedContent, .m_removeAppSupportDirectoryUnusedContent): return .match
             case (.p_currentDownloadTask_get,.p_currentDownloadTask_get): return Matcher.ComparisonResult.match
             default: return .none
             }
@@ -2440,7 +2440,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case let .m_fileUrl__for_blockId(p0): return p0.intValue
             case .m_resumeDownloading: return 0
             case let .m_isLargeVideosSize__blocks_blocks(p0): return p0.intValue
-            case .m_removeAppSupportDirectoryDeprecatedContent: return 0
+            case .m_removeAppSupportDirectoryUnusedContent: return 0
             case .p_currentDownloadTask_get: return 0
             }
         }
@@ -2460,7 +2460,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case .m_fileUrl__for_blockId: return ".fileUrl(for:)"
             case .m_resumeDownloading: return ".resumeDownloading()"
             case .m_isLargeVideosSize__blocks_blocks: return ".isLargeVideosSize(blocks:)"
-            case .m_removeAppSupportDirectoryDeprecatedContent: return ".removeAppSupportDirectoryDeprecatedContent()"
+            case .m_removeAppSupportDirectoryUnusedContent: return ".removeAppSupportDirectoryUnusedContent()"
             case .p_currentDownloadTask_get: return "[get] .currentDownloadTask"
             }
         }
@@ -2617,7 +2617,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         public static func fileUrl(for blockId: Parameter<String>) -> Verify { return Verify(method: .m_fileUrl__for_blockId(`blockId`))}
         public static func resumeDownloading() -> Verify { return Verify(method: .m_resumeDownloading)}
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>) -> Verify { return Verify(method: .m_isLargeVideosSize__blocks_blocks(`blocks`))}
-        public static func removeAppSupportDirectoryDeprecatedContent() -> Verify { return Verify(method: .m_removeAppSupportDirectoryDeprecatedContent)}
+        public static func removeAppSupportDirectoryUnusedContent() -> Verify { return Verify(method: .m_removeAppSupportDirectoryUnusedContent)}
         public static var currentDownloadTask: Verify { return Verify(method: .p_currentDownloadTask_get) }
     }
 
@@ -2667,8 +2667,8 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>, perform: @escaping ([CourseBlock]) -> Void) -> Perform {
             return Perform(method: .m_isLargeVideosSize__blocks_blocks(`blocks`), performs: perform)
         }
-        public static func removeAppSupportDirectoryDeprecatedContent(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeAppSupportDirectoryDeprecatedContent, performs: perform)
+        public static func removeAppSupportDirectoryUnusedContent(perform: @escaping () -> Void) -> Perform {
+            return Perform(method: .m_removeAppSupportDirectoryUnusedContent, performs: perform)
         }
     }
 

--- a/Discovery/DiscoveryTests/DiscoveryMock.generated.swift
+++ b/Discovery/DiscoveryTests/DiscoveryMock.generated.swift
@@ -2338,6 +2338,12 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 		return __value
     }
 
+    open func removeAppSupportDirectoryDeprecatedContent() {
+        addInvocation(.m_removeAppSupportDirectoryDeprecatedContent)
+		let perform = methodPerformValue(.m_removeAppSupportDirectoryDeprecatedContent) as? () -> Void
+		perform?()
+    }
+
 
     fileprivate enum MethodType {
         case m_publisher
@@ -2354,6 +2360,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         case m_fileUrl__for_blockId(Parameter<String>)
         case m_resumeDownloading
         case m_isLargeVideosSize__blocks_blocks(Parameter<[CourseBlock]>)
+        case m_removeAppSupportDirectoryDeprecatedContent
         case p_currentDownloadTask_get
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
@@ -2410,6 +2417,8 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsBlocks, rhs: rhsBlocks, with: matcher), lhsBlocks, rhsBlocks, "blocks"))
 				return Matcher.ComparisonResult(results)
+
+            case (.m_removeAppSupportDirectoryDeprecatedContent, .m_removeAppSupportDirectoryDeprecatedContent): return .match
             case (.p_currentDownloadTask_get,.p_currentDownloadTask_get): return Matcher.ComparisonResult.match
             default: return .none
             }
@@ -2431,6 +2440,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case let .m_fileUrl__for_blockId(p0): return p0.intValue
             case .m_resumeDownloading: return 0
             case let .m_isLargeVideosSize__blocks_blocks(p0): return p0.intValue
+            case .m_removeAppSupportDirectoryDeprecatedContent: return 0
             case .p_currentDownloadTask_get: return 0
             }
         }
@@ -2450,6 +2460,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case .m_fileUrl__for_blockId: return ".fileUrl(for:)"
             case .m_resumeDownloading: return ".resumeDownloading()"
             case .m_isLargeVideosSize__blocks_blocks: return ".isLargeVideosSize(blocks:)"
+            case .m_removeAppSupportDirectoryDeprecatedContent: return ".removeAppSupportDirectoryDeprecatedContent()"
             case .p_currentDownloadTask_get: return "[get] .currentDownloadTask"
             }
         }
@@ -2606,6 +2617,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         public static func fileUrl(for blockId: Parameter<String>) -> Verify { return Verify(method: .m_fileUrl__for_blockId(`blockId`))}
         public static func resumeDownloading() -> Verify { return Verify(method: .m_resumeDownloading)}
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>) -> Verify { return Verify(method: .m_isLargeVideosSize__blocks_blocks(`blocks`))}
+        public static func removeAppSupportDirectoryDeprecatedContent() -> Verify { return Verify(method: .m_removeAppSupportDirectoryDeprecatedContent)}
         public static var currentDownloadTask: Verify { return Verify(method: .p_currentDownloadTask_get) }
     }
 
@@ -2654,6 +2666,9 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         }
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>, perform: @escaping ([CourseBlock]) -> Void) -> Perform {
             return Perform(method: .m_isLargeVideosSize__blocks_blocks(`blocks`), performs: perform)
+        }
+        public static func removeAppSupportDirectoryDeprecatedContent(perform: @escaping () -> Void) -> Perform {
+            return Perform(method: .m_removeAppSupportDirectoryDeprecatedContent, performs: perform)
         }
     }
 

--- a/Discussion/DiscussionTests/DiscussionMock.generated.swift
+++ b/Discussion/DiscussionTests/DiscussionMock.generated.swift
@@ -3275,6 +3275,12 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 		return __value
     }
 
+    open func removeAppSupportDirectoryDeprecatedContent() {
+        addInvocation(.m_removeAppSupportDirectoryDeprecatedContent)
+		let perform = methodPerformValue(.m_removeAppSupportDirectoryDeprecatedContent) as? () -> Void
+		perform?()
+    }
+
 
     fileprivate enum MethodType {
         case m_publisher
@@ -3291,6 +3297,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         case m_fileUrl__for_blockId(Parameter<String>)
         case m_resumeDownloading
         case m_isLargeVideosSize__blocks_blocks(Parameter<[CourseBlock]>)
+        case m_removeAppSupportDirectoryDeprecatedContent
         case p_currentDownloadTask_get
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
@@ -3347,6 +3354,8 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsBlocks, rhs: rhsBlocks, with: matcher), lhsBlocks, rhsBlocks, "blocks"))
 				return Matcher.ComparisonResult(results)
+
+            case (.m_removeAppSupportDirectoryDeprecatedContent, .m_removeAppSupportDirectoryDeprecatedContent): return .match
             case (.p_currentDownloadTask_get,.p_currentDownloadTask_get): return Matcher.ComparisonResult.match
             default: return .none
             }
@@ -3368,6 +3377,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case let .m_fileUrl__for_blockId(p0): return p0.intValue
             case .m_resumeDownloading: return 0
             case let .m_isLargeVideosSize__blocks_blocks(p0): return p0.intValue
+            case .m_removeAppSupportDirectoryDeprecatedContent: return 0
             case .p_currentDownloadTask_get: return 0
             }
         }
@@ -3387,6 +3397,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case .m_fileUrl__for_blockId: return ".fileUrl(for:)"
             case .m_resumeDownloading: return ".resumeDownloading()"
             case .m_isLargeVideosSize__blocks_blocks: return ".isLargeVideosSize(blocks:)"
+            case .m_removeAppSupportDirectoryDeprecatedContent: return ".removeAppSupportDirectoryDeprecatedContent()"
             case .p_currentDownloadTask_get: return "[get] .currentDownloadTask"
             }
         }
@@ -3543,6 +3554,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         public static func fileUrl(for blockId: Parameter<String>) -> Verify { return Verify(method: .m_fileUrl__for_blockId(`blockId`))}
         public static func resumeDownloading() -> Verify { return Verify(method: .m_resumeDownloading)}
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>) -> Verify { return Verify(method: .m_isLargeVideosSize__blocks_blocks(`blocks`))}
+        public static func removeAppSupportDirectoryDeprecatedContent() -> Verify { return Verify(method: .m_removeAppSupportDirectoryDeprecatedContent)}
         public static var currentDownloadTask: Verify { return Verify(method: .p_currentDownloadTask_get) }
     }
 
@@ -3591,6 +3603,9 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         }
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>, perform: @escaping ([CourseBlock]) -> Void) -> Perform {
             return Perform(method: .m_isLargeVideosSize__blocks_blocks(`blocks`), performs: perform)
+        }
+        public static func removeAppSupportDirectoryDeprecatedContent(perform: @escaping () -> Void) -> Perform {
+            return Perform(method: .m_removeAppSupportDirectoryDeprecatedContent, performs: perform)
         }
     }
 

--- a/Discussion/DiscussionTests/DiscussionMock.generated.swift
+++ b/Discussion/DiscussionTests/DiscussionMock.generated.swift
@@ -3275,9 +3275,9 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 		return __value
     }
 
-    open func removeAppSupportDirectoryDeprecatedContent() {
-        addInvocation(.m_removeAppSupportDirectoryDeprecatedContent)
-		let perform = methodPerformValue(.m_removeAppSupportDirectoryDeprecatedContent) as? () -> Void
+    open func removeAppSupportDirectoryUnusedContent() {
+        addInvocation(.m_removeAppSupportDirectoryUnusedContent)
+		let perform = methodPerformValue(.m_removeAppSupportDirectoryUnusedContent) as? () -> Void
 		perform?()
     }
 
@@ -3297,7 +3297,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         case m_fileUrl__for_blockId(Parameter<String>)
         case m_resumeDownloading
         case m_isLargeVideosSize__blocks_blocks(Parameter<[CourseBlock]>)
-        case m_removeAppSupportDirectoryDeprecatedContent
+        case m_removeAppSupportDirectoryUnusedContent
         case p_currentDownloadTask_get
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
@@ -3355,7 +3355,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsBlocks, rhs: rhsBlocks, with: matcher), lhsBlocks, rhsBlocks, "blocks"))
 				return Matcher.ComparisonResult(results)
 
-            case (.m_removeAppSupportDirectoryDeprecatedContent, .m_removeAppSupportDirectoryDeprecatedContent): return .match
+            case (.m_removeAppSupportDirectoryUnusedContent, .m_removeAppSupportDirectoryUnusedContent): return .match
             case (.p_currentDownloadTask_get,.p_currentDownloadTask_get): return Matcher.ComparisonResult.match
             default: return .none
             }
@@ -3377,7 +3377,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case let .m_fileUrl__for_blockId(p0): return p0.intValue
             case .m_resumeDownloading: return 0
             case let .m_isLargeVideosSize__blocks_blocks(p0): return p0.intValue
-            case .m_removeAppSupportDirectoryDeprecatedContent: return 0
+            case .m_removeAppSupportDirectoryUnusedContent: return 0
             case .p_currentDownloadTask_get: return 0
             }
         }
@@ -3397,7 +3397,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case .m_fileUrl__for_blockId: return ".fileUrl(for:)"
             case .m_resumeDownloading: return ".resumeDownloading()"
             case .m_isLargeVideosSize__blocks_blocks: return ".isLargeVideosSize(blocks:)"
-            case .m_removeAppSupportDirectoryDeprecatedContent: return ".removeAppSupportDirectoryDeprecatedContent()"
+            case .m_removeAppSupportDirectoryUnusedContent: return ".removeAppSupportDirectoryUnusedContent()"
             case .p_currentDownloadTask_get: return "[get] .currentDownloadTask"
             }
         }
@@ -3554,7 +3554,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         public static func fileUrl(for blockId: Parameter<String>) -> Verify { return Verify(method: .m_fileUrl__for_blockId(`blockId`))}
         public static func resumeDownloading() -> Verify { return Verify(method: .m_resumeDownloading)}
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>) -> Verify { return Verify(method: .m_isLargeVideosSize__blocks_blocks(`blocks`))}
-        public static func removeAppSupportDirectoryDeprecatedContent() -> Verify { return Verify(method: .m_removeAppSupportDirectoryDeprecatedContent)}
+        public static func removeAppSupportDirectoryUnusedContent() -> Verify { return Verify(method: .m_removeAppSupportDirectoryUnusedContent)}
         public static var currentDownloadTask: Verify { return Verify(method: .p_currentDownloadTask_get) }
     }
 
@@ -3604,8 +3604,8 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>, perform: @escaping ([CourseBlock]) -> Void) -> Perform {
             return Perform(method: .m_isLargeVideosSize__blocks_blocks(`blocks`), performs: perform)
         }
-        public static func removeAppSupportDirectoryDeprecatedContent(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeAppSupportDirectoryDeprecatedContent, performs: perform)
+        public static func removeAppSupportDirectoryUnusedContent(perform: @escaping () -> Void) -> Perform {
+            return Perform(method: .m_removeAppSupportDirectoryUnusedContent, performs: perform)
         }
     }
 

--- a/OpenEdX/Data/AppStorage.swift
+++ b/OpenEdX/Data/AppStorage.swift
@@ -203,7 +203,20 @@ public class AppStorage: CoreStorage, ProfileStorage, WhatsNewStorage, CourseSto
             }
         }
     }
-
+    
+    public var resetAppSupportDirectoryUserData: Bool? {
+        get {
+            return userDefaults.bool(forKey: KEY_RESET_APP_SUPPORT_DIRECTORY_USER_DATA)
+        }
+        set(newValue) {
+            if let newValue {
+                userDefaults.set(newValue, forKey: KEY_RESET_APP_SUPPORT_DIRECTORY_USER_DATA)
+            } else {
+                userDefaults.removeObject(forKey: KEY_RESET_APP_SUPPORT_DIRECTORY_USER_DATA)
+            }
+        }
+    }
+    
     public func clear() {
         accessToken = nil
         refreshToken = nil
@@ -223,4 +236,5 @@ public class AppStorage: CoreStorage, ProfileStorage, WhatsNewStorage, CourseSto
     private let KEY_APPLE_SIGN_FULLNAME = "appleSignFullName"
     private let KEY_APPLE_SIGN_EMAIL = "appleSignEmail"
     private let KEY_ALLOWED_DOWNLOAD_LARGE_FILE = "allowedDownloadLargeFile"
+    private let KEY_RESET_APP_SUPPORT_DIRECTORY_USER_DATA = "resetAppSupportDirectoryUserData"
 }

--- a/OpenEdX/RouteController.swift
+++ b/OpenEdX/RouteController.swift
@@ -109,13 +109,14 @@ class RouteController: UIViewController {
      all users have transitioned to the new application.
      */
     private func resetAppSupportDirectoryUserData() {
-        if var upgradationValue = Container.shared.resolve(CoreStorage.self) {
-            if upgradationValue.resetAppSupportDirectoryUserData == false {
-                Task {
-                    Container.shared.resolve(DownloadManagerProtocol.self)?.removeAppSupportDirectoryDeprecatedContent()
-                    upgradationValue.resetAppSupportDirectoryUserData = true
-                }
-            }
+        guard var upgradationValue = Container.shared.resolve(CoreStorage.self),
+              let downloadManager = Container.shared.resolve(DownloadManagerProtocol.self),
+              upgradationValue.resetAppSupportDirectoryUserData == false
+        else { return }
+        
+        Task {
+            downloadManager.removeAppSupportDirectoryUnusedContent()
+            upgradationValue.resetAppSupportDirectoryUserData = true
         }
     }
 }

--- a/OpenEdX/RouteController.swift
+++ b/OpenEdX/RouteController.swift
@@ -44,6 +44,7 @@ class RouteController: UIViewController {
             }
         }
         
+        resetAppSupportDirectoryUserData()
         coreAnalytics.trackEvent(.launch, biValue: .launch)
     }
     
@@ -98,5 +99,23 @@ class RouteController: UIViewController {
             navigation.viewControllers = [controller]
         }
         present(navigation, animated: false)
+    }
+
+    /**
+     This code will delete any old application’s downloaded user data, such as video files,
+     from the Application Support directory to optimize storage. This activity will be performed
+     only once during the upgrade from the old Open edX application to the new one or during
+     fresh installation. We can consider removing this code once we are confident that most or
+     all users have transitioned to the new application.
+     */
+    private func resetAppSupportDirectoryUserData() {
+        if var upgradationValue = Container.shared.resolve(CoreStorage.self) {
+            if upgradationValue.resetAppSupportDirectoryUserData == false {
+                Task {
+                    Container.shared.resolve(DownloadManagerProtocol.self)?.removeAppSupportDirectoryDeprecatedContent()
+                    upgradationValue.resetAppSupportDirectoryUserData = true
+                }
+            }
+        }
     }
 }

--- a/Profile/ProfileTests/ProfileMock.generated.swift
+++ b/Profile/ProfileTests/ProfileMock.generated.swift
@@ -1612,9 +1612,9 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 		return __value
     }
 
-    open func removeAppSupportDirectoryDeprecatedContent() {
-        addInvocation(.m_removeAppSupportDirectoryDeprecatedContent)
-		let perform = methodPerformValue(.m_removeAppSupportDirectoryDeprecatedContent) as? () -> Void
+    open func removeAppSupportDirectoryUnusedContent() {
+        addInvocation(.m_removeAppSupportDirectoryUnusedContent)
+		let perform = methodPerformValue(.m_removeAppSupportDirectoryUnusedContent) as? () -> Void
 		perform?()
     }
 
@@ -1634,7 +1634,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         case m_fileUrl__for_blockId(Parameter<String>)
         case m_resumeDownloading
         case m_isLargeVideosSize__blocks_blocks(Parameter<[CourseBlock]>)
-        case m_removeAppSupportDirectoryDeprecatedContent
+        case m_removeAppSupportDirectoryUnusedContent
         case p_currentDownloadTask_get
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
@@ -1692,7 +1692,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsBlocks, rhs: rhsBlocks, with: matcher), lhsBlocks, rhsBlocks, "blocks"))
 				return Matcher.ComparisonResult(results)
 
-            case (.m_removeAppSupportDirectoryDeprecatedContent, .m_removeAppSupportDirectoryDeprecatedContent): return .match
+            case (.m_removeAppSupportDirectoryUnusedContent, .m_removeAppSupportDirectoryUnusedContent): return .match
             case (.p_currentDownloadTask_get,.p_currentDownloadTask_get): return Matcher.ComparisonResult.match
             default: return .none
             }
@@ -1714,7 +1714,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case let .m_fileUrl__for_blockId(p0): return p0.intValue
             case .m_resumeDownloading: return 0
             case let .m_isLargeVideosSize__blocks_blocks(p0): return p0.intValue
-            case .m_removeAppSupportDirectoryDeprecatedContent: return 0
+            case .m_removeAppSupportDirectoryUnusedContent: return 0
             case .p_currentDownloadTask_get: return 0
             }
         }
@@ -1734,7 +1734,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case .m_fileUrl__for_blockId: return ".fileUrl(for:)"
             case .m_resumeDownloading: return ".resumeDownloading()"
             case .m_isLargeVideosSize__blocks_blocks: return ".isLargeVideosSize(blocks:)"
-            case .m_removeAppSupportDirectoryDeprecatedContent: return ".removeAppSupportDirectoryDeprecatedContent()"
+            case .m_removeAppSupportDirectoryUnusedContent: return ".removeAppSupportDirectoryUnusedContent()"
             case .p_currentDownloadTask_get: return "[get] .currentDownloadTask"
             }
         }
@@ -1891,7 +1891,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         public static func fileUrl(for blockId: Parameter<String>) -> Verify { return Verify(method: .m_fileUrl__for_blockId(`blockId`))}
         public static func resumeDownloading() -> Verify { return Verify(method: .m_resumeDownloading)}
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>) -> Verify { return Verify(method: .m_isLargeVideosSize__blocks_blocks(`blocks`))}
-        public static func removeAppSupportDirectoryDeprecatedContent() -> Verify { return Verify(method: .m_removeAppSupportDirectoryDeprecatedContent)}
+        public static func removeAppSupportDirectoryUnusedContent() -> Verify { return Verify(method: .m_removeAppSupportDirectoryUnusedContent)}
         public static var currentDownloadTask: Verify { return Verify(method: .p_currentDownloadTask_get) }
     }
 
@@ -1941,8 +1941,8 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>, perform: @escaping ([CourseBlock]) -> Void) -> Perform {
             return Perform(method: .m_isLargeVideosSize__blocks_blocks(`blocks`), performs: perform)
         }
-        public static func removeAppSupportDirectoryDeprecatedContent(perform: @escaping () -> Void) -> Perform {
-            return Perform(method: .m_removeAppSupportDirectoryDeprecatedContent, performs: perform)
+        public static func removeAppSupportDirectoryUnusedContent(perform: @escaping () -> Void) -> Perform {
+            return Perform(method: .m_removeAppSupportDirectoryUnusedContent, performs: perform)
         }
     }
 

--- a/Profile/ProfileTests/ProfileMock.generated.swift
+++ b/Profile/ProfileTests/ProfileMock.generated.swift
@@ -1612,6 +1612,12 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 		return __value
     }
 
+    open func removeAppSupportDirectoryDeprecatedContent() {
+        addInvocation(.m_removeAppSupportDirectoryDeprecatedContent)
+		let perform = methodPerformValue(.m_removeAppSupportDirectoryDeprecatedContent) as? () -> Void
+		perform?()
+    }
+
 
     fileprivate enum MethodType {
         case m_publisher
@@ -1628,6 +1634,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         case m_fileUrl__for_blockId(Parameter<String>)
         case m_resumeDownloading
         case m_isLargeVideosSize__blocks_blocks(Parameter<[CourseBlock]>)
+        case m_removeAppSupportDirectoryDeprecatedContent
         case p_currentDownloadTask_get
 
         static func compareParameters(lhs: MethodType, rhs: MethodType, matcher: Matcher) -> Matcher.ComparisonResult {
@@ -1684,6 +1691,8 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
 				var results: [Matcher.ParameterComparisonResult] = []
 				results.append(Matcher.ParameterComparisonResult(Parameter.compare(lhs: lhsBlocks, rhs: rhsBlocks, with: matcher), lhsBlocks, rhsBlocks, "blocks"))
 				return Matcher.ComparisonResult(results)
+
+            case (.m_removeAppSupportDirectoryDeprecatedContent, .m_removeAppSupportDirectoryDeprecatedContent): return .match
             case (.p_currentDownloadTask_get,.p_currentDownloadTask_get): return Matcher.ComparisonResult.match
             default: return .none
             }
@@ -1705,6 +1714,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case let .m_fileUrl__for_blockId(p0): return p0.intValue
             case .m_resumeDownloading: return 0
             case let .m_isLargeVideosSize__blocks_blocks(p0): return p0.intValue
+            case .m_removeAppSupportDirectoryDeprecatedContent: return 0
             case .p_currentDownloadTask_get: return 0
             }
         }
@@ -1724,6 +1734,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
             case .m_fileUrl__for_blockId: return ".fileUrl(for:)"
             case .m_resumeDownloading: return ".resumeDownloading()"
             case .m_isLargeVideosSize__blocks_blocks: return ".isLargeVideosSize(blocks:)"
+            case .m_removeAppSupportDirectoryDeprecatedContent: return ".removeAppSupportDirectoryDeprecatedContent()"
             case .p_currentDownloadTask_get: return "[get] .currentDownloadTask"
             }
         }
@@ -1880,6 +1891,7 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         public static func fileUrl(for blockId: Parameter<String>) -> Verify { return Verify(method: .m_fileUrl__for_blockId(`blockId`))}
         public static func resumeDownloading() -> Verify { return Verify(method: .m_resumeDownloading)}
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>) -> Verify { return Verify(method: .m_isLargeVideosSize__blocks_blocks(`blocks`))}
+        public static func removeAppSupportDirectoryDeprecatedContent() -> Verify { return Verify(method: .m_removeAppSupportDirectoryDeprecatedContent)}
         public static var currentDownloadTask: Verify { return Verify(method: .p_currentDownloadTask_get) }
     }
 
@@ -1928,6 +1940,9 @@ open class DownloadManagerProtocolMock: DownloadManagerProtocol, Mock {
         }
         public static func isLargeVideosSize(blocks: Parameter<[CourseBlock]>, perform: @escaping ([CourseBlock]) -> Void) -> Perform {
             return Perform(method: .m_isLargeVideosSize__blocks_blocks(`blocks`), performs: perform)
+        }
+        public static func removeAppSupportDirectoryDeprecatedContent(perform: @escaping () -> Void) -> Perform {
+            return Perform(method: .m_removeAppSupportDirectoryDeprecatedContent, performs: perform)
         }
     }
 


### PR DESCRIPTION
[LEARNER-9966](https://2u-internal.atlassian.net/browse/LEARNER-9966): Delete old downloaded videos data on device to optimize storage

We decided not to migrate downloaded content but have to look into deleting the old downloaded videos so the app does not create useless dummy data in the learners' devices.

**Technical Details:**
The old application saves users' downloaded videos in the `Application Support` directory within folders named users' MD5 hashes. When multiple users log into the same device, separate MD5 hashed folders are created for each user, each containing that user's downloaded data.

After upgrading the application, we can use the MD5 hash algorithm to delete only the data of the currently logged-in user, while the data for other users will remain intact. Because MD5 hash folder name will be generated for current logged in username. To prevent this scenario, we need to create a regex that identifies and deletes all MD5 hashed folders upon launching the upgraded application.

We can consider removing this code once we are confident that most or all users have transitioned to the new application.

| Before Update Size | After Update Size |
|----------|----------|
| ![Before Update Size](https://github.com/openedx/openedx-app-ios/assets/11990137/e13c9d15-1d98-4e34-a027-051a27fb27c8) | ![After Update Size](https://github.com/openedx/openedx-app-ios/assets/11990137/46d69baa-1bc1-4bd2-b1e4-d85fa33b48e8) |


Before Update | After Update |
--- | --- | 
<video src="https://github.com/openedx/openedx-app-ios/assets/11990137/de782e20-a14b-4645-a363-24c6beae4cf6" /> | <video src="https://github.com/openedx/openedx-app-ios/assets/11990137/b5df90ca-e78a-4c17-8ca9-7a5bc9847c4d" /> | 