### PR TITLE
Small fix for deleting downloaded files

### DIFF
--- a/Core/Core/Network/DownloadManager.swift
+++ b/Core/Core/Network/DownloadManager.swift
@@ -274,11 +274,11 @@ public class DownloadManager: DownloadManagerProtocol {
     public func deleteFile(blocks: [CourseBlock]) async {
         for block in blocks {
             do {
-                try persistence.deleteDownloadDataTask(id: block.id)
-                currentDownloadEventPublisher.send(.deletedFile(block.id))
                 if let fileURL = await fileUrl(for: block.id) {
                     try FileManager.default.removeItem(at: fileURL)
                 }
+                try persistence.deleteDownloadDataTask(id: block.id)
+                currentDownloadEventPublisher.send(.deletedFile(block.id))
             } catch {
                 debugLog("Error deleting file: \(error.localizedDescription)")
             }


### PR DESCRIPTION
This is small fix for issue https://github.com/openedx/openedx-app-ios/issues/451
For some reason we deleted the data from DB first and then tried to delete the local file, but the url of the file is built on the data from DB. Now it's fixed