### PR TITLE
Fix video quality settings in modal representation

### DIFF
--- a/Core/Core/View/Base/VideoDownloadQualityView.swift
+++ b/Core/Core/View/Base/VideoDownloadQualityView.swift
@@ -219,7 +219,7 @@ public extension DownloadQuality {
 }
 
 #if DEBUG
-struct AddTopic_Previews: PreviewProvider {
+struct VideoDownloadQualityView_Previews: PreviewProvider {
     static var previews: some View {
         VideoDownloadQualityView(
             downloadQuality: .auto,

--- a/Core/Core/View/Base/VideoDownloadQualityView.swift
+++ b/Core/Core/View/Base/VideoDownloadQualityView.swift
@@ -34,13 +34,15 @@ public struct VideoDownloadQualityView: View {
     private var viewModel: VideoDownloadQualityViewModel
     private var analytics: CoreAnalytics
     private var router: BaseRouter
+    private var isModal: Bool
     @Environment (\.isHorizontal) private var isHorizontal
 
     public init(
         downloadQuality: DownloadQuality,
         didSelect: ((DownloadQuality) -> Void)?,
         analytics: CoreAnalytics,
-        router: BaseRouter
+        router: BaseRouter,
+        isModal: Bool = false
     ) {
         self._viewModel = StateObject(
             wrappedValue: .init(
@@ -50,41 +52,46 @@ public struct VideoDownloadQualityView: View {
         )
         self.analytics = analytics
         self.router = router
+        self.isModal = isModal
     }
 
     public var body: some View {
         GeometryReader { proxy in
             ZStack(alignment: .top) {
-                VStack {
-                    ThemeAssets.headerBackground.swiftUIImage
-                        .resizable()
-                        .edgesIgnoringSafeArea(.top)
+                if !isModal {
+                    VStack {
+                        ThemeAssets.headerBackground.swiftUIImage
+                            .resizable()
+                            .edgesIgnoringSafeArea(.top)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: 200)
+                    .accessibilityIdentifier("auth_bg_image")
                 }
-                .frame(maxWidth: .infinity, maxHeight: 200)
-                .accessibilityIdentifier("auth_bg_image")
                 
                 // MARK: - Page name
                 VStack(alignment: .center) {
-                    ZStack {
-                        HStack {
-                            Text(CoreLocalization.Settings.videoDownloadQualityTitle)
-                                .titleSettings(color: Theme.Colors.loginNavigationText)
-                                .accessibilityIdentifier("manage_account_text")
+                    if !isModal {
+                        ZStack {
+                            HStack {
+                                Text(CoreLocalization.Settings.videoDownloadQualityTitle)
+                                    .titleSettings(color: Theme.Colors.loginNavigationText)
+                                    .accessibilityIdentifier("manage_account_text")
+                            }
+                            VStack {
+                                BackNavigationButton(
+                                    color: Theme.Colors.loginNavigationText,
+                                    action: {
+                                        router.back()
+                                    }
+                                )
+                                .backViewStyle()
+                                .padding(.leading, isHorizontal ? 48 : 0)
+                                .accessibilityIdentifier("back_button")
+                                
+                            }.frame(minWidth: 0,
+                                    maxWidth: .infinity,
+                                    alignment: .topLeading)
                         }
-                        VStack {
-                            BackNavigationButton(
-                                color: Theme.Colors.loginNavigationText,
-                                action: {
-                                    router.back()
-                                }
-                            )
-                            .backViewStyle()
-                            .padding(.leading, isHorizontal ? 48 : 0)
-                            .accessibilityIdentifier("back_button")
-                            
-                        }.frame(minWidth: 0,
-                                maxWidth: .infinity,
-                                alignment: .topLeading)
                     }
                     // MARK: - Page Body
                     ScrollView {
@@ -129,8 +136,8 @@ public struct VideoDownloadQualityView: View {
                 }
             }
         }
-        .navigationBarHidden(true)
-        .navigationBarBackButtonHidden(true)
+        .navigationBarHidden(!isModal)
+        .navigationBarBackButtonHidden(!isModal)
         .navigationTitle(CoreLocalization.Settings.videoDownloadQualityTitle)
         .ignoresSafeArea(.all, edges: .horizontal)
         .background(
@@ -210,3 +217,17 @@ public extension DownloadQuality {
         }
     }
 }
+
+#if DEBUG
+struct AddTopic_Previews: PreviewProvider {
+    static var previews: some View {
+        VideoDownloadQualityView(
+            downloadQuality: .auto,
+            didSelect: nil,
+            analytics: CoreAnalyticsMock(),
+            router: BaseRouterMock(),
+            isModal: true
+        )
+    }
+}
+#endif

--- a/Course/Course/Presentation/Outline/CourseOutlineView.swift
+++ b/Course/Course/Presentation/Outline/CourseOutlineView.swift
@@ -205,7 +205,8 @@ public struct CourseOutlineView: View {
                     downloadQuality: $0.downloadQuality,
                     didSelect: viewModel.update(downloadQuality:),
                     analytics: viewModel.coreAnalytics,
-                    router: viewModel.router
+                    router: viewModel.router,
+                    isModal: true
                 )
             }
         }

--- a/Course/Course/Presentation/Subviews/VideoDownloadQualityBarView/VideoDownloadQualityContainerView.swift
+++ b/Course/Course/Presentation/Subviews/VideoDownloadQualityBarView/VideoDownloadQualityContainerView.swift
@@ -17,17 +17,20 @@ struct VideoDownloadQualityContainerView: View {
     private var didSelect: ((DownloadQuality) -> Void)?
     private let analytics: CoreAnalytics
     private let router: CourseRouter
+    private var isModal: Bool
 
     init(
         downloadQuality: DownloadQuality,
         didSelect: ((DownloadQuality) -> Void)?,
         analytics: CoreAnalytics,
-        router: CourseRouter
+        router: CourseRouter,
+        isModal: Bool = false
     ) {
         self.downloadQuality = downloadQuality
         self.didSelect = didSelect
         self.analytics = analytics
         self.router = router
+        self.isModal = isModal
     }
 
     var body: some View {
@@ -36,7 +39,8 @@ struct VideoDownloadQualityContainerView: View {
                 downloadQuality: downloadQuality,
                 didSelect: didSelect,
                 analytics: analytics,
-                router: router
+                router: router,
+                isModal: isModal
             )
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {


### PR DESCRIPTION
This PR is the fix for https://github.com/openedx/openedx-app-ios/issues/436
In a modal view, the modal representation of that view should be used.
Added `isModal` parameter with a default value of `false`, which determines which presentation will be used.
The full screen view  in the Settings does not change.

Now | After fix
--- | ---
<img width="250" src="https://github.com/openedx/openedx-app-ios/assets/37253/89e32876-6560-49f3-a52c-cb733ce681f4"> | <img width="250" src="https://github.com/openedx/openedx-app-ios/assets/37253/817abee4-339e-41ba-b0de-d3663263730c">
