### PR TITLE
[iOS] Unnecessary loading indicator in the download queue #285

### DIFF
--- a/Course/Course/Presentation/Downloads/DownloadsView.swift
+++ b/Course/Course/Presentation/Downloads/DownloadsView.swift
@@ -126,6 +126,7 @@ public struct DownloadsView: View {
                         }
                     } label: {
                         DownloadProgressView()
+                            .id("cirle loading indicator " + task.id)
                             .accessibilityElement(children: .ignore)
                             .accessibilityLabel(CourseLocalization.Accessibility.cancelDownload)
                             .accessibilityIdentifier("cancel_download_button")


### PR DESCRIPTION
[iOS] Unnecessary loading indicator in the download queue #285

Before fix:
https://github.com/openedx/openedx-app-ios/assets/2964930/96e08a77-bad8-4a22-bd43-0da1164ec4ff

After fix:

https://github.com/openedx/openedx-app-ios/assets/480059/5fe53b01-dce3-473a-9ec7-19a22bb48879

