### PR TITLE
Settings button for dashboard type 'list'

### DIFF
--- a/Dashboard/Dashboard/Presentation/ListDashboardView.swift
+++ b/Dashboard/Dashboard/Presentation/ListDashboardView.swift
@@ -27,6 +27,7 @@ public struct ListDashboardView: View {
     @StateObject
     private var viewModel: ListDashboardViewModel
     private let router: DashboardRouter
+    private var idiom: UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }
     
     public init(viewModel: ListDashboardViewModel, router: DashboardRouter) {
         self._viewModel = StateObject(wrappedValue: { viewModel }())
@@ -103,6 +104,17 @@ public struct ListDashboardView: View {
                         .frameLimit(width: proxy.size.width)
                     }.accessibilityAction {}
                 }.padding(.top, 8)
+                HStack {
+                    Spacer()
+                    Button(action: {
+                        router.showSettings()
+                    }, label: {
+                        CoreAssets.settings.swiftUIImage.renderingMode(.template)
+                            .foregroundColor(Theme.Colors.accentColor)
+                    })
+                }
+                .padding(.top, idiom == .pad ? 13 : 5)
+                .padding(.trailing, idiom == .pad ? 20 : 16)
                 
                 // MARK: - Offline mode SnackBar
                 OfflineSnackBarView(connectivity: viewModel.connectivity,


### PR DESCRIPTION
This PR fixes issue https://github.com/openedx/openedx-app-ios/issues/468 where Settings button is missed for Dashboard type "list"
After fix:
iPhone | iPad
--- | ---
<img width="250" src="https://github.com/openedx/openedx-app-ios/assets/37253/d7968087-4375-4152-9547-018e9ae986f9"> | <img width="350" src="https://github.com/openedx/openedx-app-ios/assets/37253/7e4fecf8-2b47-440c-a630-55b96b2571d5">

