### PR TITLE
Fixes for downloading

### DIFF
--- a/Core/Core/Network/DownloadManager.swift
+++ b/Core/Core/Network/DownloadManager.swift
@@ -274,7 +274,6 @@ public class DownloadManager: DownloadManagerProtocol {
     }
 
     public func deleteFile(blocks: [CourseBlock]) async {
-        print("!!! deleteFile(blocks: count = \(blocks.count)")
         for block in blocks {
             do {
                 if let fileURL = await fileUrl(for: block.id) {


### PR DESCRIPTION
This PR fixes next issues:
- https://github.com/openedx/openedx-app-ios/issues/485
- https://github.com/openedx/openedx-app-ios/issues/458

To fix the remaining tmp files, `DownloadRequest.Destination` was added with the setting `.removePreviousFile`.
The way we cancel downloads at the chapter level has also been changed: since we have no individual control at this level, we must cancel and remove all files in the chapter to prevent a situation where we cancel a download but the files remain.