### PR TITLE
fix: fix coredata crash on primary course

### DIFF
--- a/OpenEdX/Data/DashboardPersistence.swift
+++ b/OpenEdX/Data/DashboardPersistence.swift
@@ -231,7 +231,7 @@ public class DashboardPersistence: DashboardPersistenceProtocol {
     // swiftlint:enable function_body_length
     
     func clearOldEnrollmentsData() {
-        context.perform {[context] in
+        context.performAndWait {[context] in
             let fetchRequest1: NSFetchRequest<NSFetchRequestResult> = CDDashboardCourse.fetchRequest()
             let batchDeleteRequest1 = NSBatchDeleteRequest(fetchRequest: fetchRequest1)
             


### PR DESCRIPTION
This PR fixes the crash with coredata. Although, I'm not able to reproduce the crash  but from dry run it it can occur because of deleting the data async and right before saving new data and expecting the data will be deleted. 

Crash Link: https://console.firebase.google.com/u/1/project/openedx-mobile/crashlytics/app/ios:org.edx.mobile/issues/cb09ae273338d6fa32acb9f64effefbf?time=last-seven-days&types=crash&versions=6.0.0%20(2)&sessionEventKey=f4c972ede3fd4c18901af18a71e6b702_1979319760445579771

<img width="1104" alt="Screenshot 2024-08-09 at 8 03 46 AM" src="https://github.com/user-attachments/assets/f265b56b-59d1-4ffb-9dc3-05a511bfaf9a">
