### PR TITLE
fix: The latest facebook sdk issue

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -2466,7 +2466,7 @@
 			repositoryURL = "https://github.com/facebook/facebook-ios-sdk";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 17.4.0;
+				minimumVersion = 16.3.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Course/Course/Presentation/Unit/Subviews/NotAvailableOnMobileView.swift
+++ b/Course/Course/Presentation/Unit/Subviews/NotAvailableOnMobileView.swift
@@ -31,7 +31,8 @@ public struct NotAvailableOnMobileView: View {
                     .padding(.top, 12)
                 StyledButton(CourseLocalization.NotAvaliable.button, action: {
                     if let url = URL(string: url), UIApplication.shared.canOpenURL(url) {
-                        UIApplication.shared.open(url)
+                        // Added empty options to avoid calling overridden open(url) function in facebook sdk
+                        UIApplication.shared.open(url, options: [:])
                     }
                 })
                 .frame(width: 215)


### PR DESCRIPTION
This PR fixes an application startup crash on application startup
![image](https://github.com/user-attachments/assets/8790235f-6127-4792-974a-0d3638263776)

Downgrading the Facebook SDK version solves the problem