### PR TITLE
fix: Quick fix whitelabel script error

### DIFF
--- a/config_script/whitelabel.py
+++ b/config_script/whitelabel.py
@@ -430,7 +430,7 @@ class WhitelabelApp:
             logging.debug("DEVELOPMENT_TEAM for '"+target+"' target was set successfuly")
         # if nothing was found
         elif re.search(parameter_regex, config_file_string) is None:
-                logging.error("Check regex please. Nothing was found for 'DEVELOPMENT_TEAM' in '"+target+" target project file")
+                logging.error("Check regex please. Nothing was found for 'DEVELOPMENT_TEAM' in '"+target+"' target project file")
         else:
             logging.debug("Looks like DEVELOPMENT_TEAM for '"+target+"' target is set already")
     

--- a/config_script/whitelabel.py
+++ b/config_script/whitelabel.py
@@ -569,6 +569,7 @@ class WhitelabelApp:
                         if config_folder:
                             # example of usage
                             # project_file_string = self.replace_fullstory_flag(project_file_string, config_directory, name, config_folder, errors_texts)
+                            pass
                         else:
                             logging.error("Config folder for '"+config['env_config']+"' is not defined in config_settings.yaml->config_mapping")
                     else:

--- a/config_script/whitelabel.py
+++ b/config_script/whitelabel.py
@@ -364,7 +364,7 @@ class WhitelabelApp:
                 # define regex rule and replacement string for every possible parameter
                 if parameter == "dev_team":
                     parameter_string = 'DEVELOPMENT_TEAM = '+parameter_value+';'
-                    parameter_regex = 'DEVELOPMENT_TEAM = .{10};'
+                    parameter_regex = 'DEVELOPMENT_TEAM = (.{10}|\"\");'
                 elif parameter == "marketing_version":
                     parameter_string = 'MARKETING_VERSION = '+parameter_value+';'
                     parameter_regex = 'MARKETING_VERSION = .*;'
@@ -419,7 +419,7 @@ class WhitelabelApp:
         config_file_string_out = config_file_string
         # string and regex for dev team
         parameter_string = 'DEVELOPMENT_TEAM = '+dev_team+';'
-        parameter_regex = 'DEVELOPMENT_TEAM = .{10};'
+        parameter_regex = 'DEVELOPMENT_TEAM = (.{10}|\"\");'
         # replace all regex findings with new parameters string
         config_file_string_out = re.sub(parameter_regex, parameter_string, config_file_string)
         # if something was changed


### PR DESCRIPTION
Fix whitelabel script execution after commenting out Fullstory function - added `pass` into empty `if`
Without this script produces error:
```
  File ".../config_script/whitelabel.py", line 572
    else:
    ^
IndentationError: expected an indented block after 'if' statement on line 569
... % python3 config_script/whitelabel.py --config-file=../edx-mobile-config/openEdXAssets/whitelabel.yaml
```

Also updated regex to find the development team in the project file, as it could be empty