### PR TITLE
chore: added SSO switch-on check 

### DIFF
--- a/Authorization/Authorization/Presentation/Startup/StartupView.swift
+++ b/Authorization/Authorization/Presentation/Startup/StartupView.swift
@@ -101,7 +101,9 @@ public struct StartupView: View {
                     }
                     .padding(.horizontal, isHorizontal ? 10 : 24)
                     
-                    LogistrationBottomView { buttonAction in
+                    LogistrationBottomView(
+                        ssoEnabled: viewModel.config.uiComponents.samlSSOLoginEnabled
+                    ) { buttonAction in
                         switch buttonAction {
                         case .signIn:
                             viewModel.router.showLoginScreen(sourceScreen: .startup)
@@ -139,7 +141,8 @@ struct StartupView_Previews: PreviewProvider {
     static var previews: some View {
         let vm = StartupViewModel(
             router: AuthorizationRouterMock(),
-            analytics: CoreAnalyticsMock()
+            analytics: CoreAnalyticsMock(),
+            config: ConfigMock()
         )
         
         StartupView(viewModel: vm)

--- a/Authorization/Authorization/Presentation/Startup/StartupViewModel.swift
+++ b/Authorization/Authorization/Presentation/Startup/StartupViewModel.swift
@@ -12,15 +12,18 @@ import Core
 public class StartupViewModel: ObservableObject {
     let router: AuthorizationRouter
     let analytics: CoreAnalytics
+    let config: ConfigProtocol
     
     @Published var searchQuery: String?
     
     public init(
         router: AuthorizationRouter,
-        analytics: CoreAnalytics
+        analytics: CoreAnalytics,
+        config: ConfigProtocol
     ) {
         self.router = router
         self.analytics = analytics
+        self.config = config
     }
     
     func logAnalytics(searchQuery: String?) {

--- a/Core/Core/View/Base/LogistrationBottomView.swift
+++ b/Core/Core/View/Base/LogistrationBottomView.swift
@@ -25,10 +25,12 @@ public enum LogistrationAction: Sendable {
 
 public struct LogistrationBottomView: View {
     private let action: (LogistrationAction) -> Void
+    private let ssoEnabled: Bool
     
     @Environment(\.isHorizontal) private var isHorizontal
     
-    public init(_ action: @escaping (LogistrationAction) -> Void) {
+    public init(ssoEnabled: Bool, _ action: @escaping (LogistrationAction) -> Void) {
+        self.ssoEnabled = ssoEnabled
         self.action = action
     }
 
@@ -52,17 +54,19 @@ public struct LogistrationBottomView: View {
                 .frame(width: 100)
                 .accessibilityIdentifier("logistration_signin_button")
                 
-                StyledButton(
-                    CoreLocalization.SignIn.logInWithSsoBtn,
-                    action: {
-                        action(.signInWithSSO)
-                    },
-                    color: Theme.Colors.white,
-                    textColor: Theme.Colors.secondaryButtonTextColor,
-                    borderColor: Theme.Colors.secondaryButtonBorderColor
-                )
-                .frame(width: 100)
-                .accessibilityIdentifier("logistration_signin_withsso_button")
+                if ssoEnabled {
+                    StyledButton(
+                        CoreLocalization.SignIn.logInWithSsoBtn,
+                        action: {
+                            action(.signInWithSSO)
+                        },
+                        color: Theme.Colors.white,
+                        textColor: Theme.Colors.secondaryButtonTextColor,
+                        borderColor: Theme.Colors.secondaryButtonBorderColor
+                    )
+                    .frame(width: 100)
+                    .accessibilityIdentifier("logistration_signin_withsso_button")
+                }
             }
             .padding(.horizontal, isHorizontal ? 0 :  0)
         }
@@ -73,12 +77,12 @@ public struct LogistrationBottomView: View {
 #if DEBUG
 struct LogistrationBottomView_Previews: PreviewProvider {
     static var previews: some View {
-        LogistrationBottomView {_ in }
+        LogistrationBottomView(ssoEnabled: false) {_ in }
             .preferredColorScheme(.light)
             .previewDisplayName("StartupView Light")
             .loadFonts()
         
-        LogistrationBottomView {_ in }
+        LogistrationBottomView(ssoEnabled: false) {_ in }
             .preferredColorScheme(.dark)
             .previewDisplayName("StartupView Dark")
             .loadFonts()

--- a/Discovery/Discovery/Presentation/NativeDiscovery/CourseDetailsView.swift
+++ b/Discovery/Discovery/Presentation/NativeDiscovery/CourseDetailsView.swift
@@ -150,7 +150,9 @@ public struct CourseDetailsView: View {
                     }
                 }
                 if !viewModel.userloggedIn {
-                    LogistrationBottomView { buttonAction in
+                    LogistrationBottomView(
+                        ssoEnabled: viewModel.config.uiComponents.samlSSOLoginEnabled
+                    ) { buttonAction in
                         switch buttonAction {
                         case .signIn:
                             viewModel.router.showLoginScreen(

--- a/Discovery/Discovery/Presentation/NativeDiscovery/DiscoveryView.swift
+++ b/Discovery/Discovery/Presentation/NativeDiscovery/DiscoveryView.swift
@@ -149,7 +149,9 @@ public struct DiscoveryView: View {
                 }.accessibilityAction {}
 
                 if !viewModel.userloggedIn {
-                    LogistrationBottomView { buttonAction in
+                    LogistrationBottomView(
+                        ssoEnabled: viewModel.config.uiComponents.samlSSOLoginEnabled
+                    ) { buttonAction in
                         switch buttonAction {
                         case .signIn:
                             viewModel.router.showLoginScreen(sourceScreen: .discovery)

--- a/Discovery/Discovery/Presentation/WebDiscovery/DiscoveryWebview.swift
+++ b/Discovery/Discovery/Presentation/WebDiscovery/DiscoveryWebview.swift
@@ -134,7 +134,9 @@ public struct DiscoveryWebview: View {
                     }
 
                     if !viewModel.userloggedIn, !isLoading {
-                        LogistrationBottomView { buttonAction in
+                        LogistrationBottomView(
+                            ssoEnabled: viewModel.config.uiComponents.samlSSOLoginEnabled
+                        ) { buttonAction in
                             switch buttonAction {
                             case .signIn:
                                 viewModel.router.showLoginScreen(sourceScreen: sourceScreen)

--- a/OpenEdX/DI/ScreenAssembly.swift
+++ b/OpenEdX/DI/ScreenAssembly.swift
@@ -74,7 +74,8 @@ class ScreenAssembly: Assembly {
         container.register(StartupViewModel.self) { @MainActor r in
             StartupViewModel(
                 router: r.resolve(AuthorizationRouter.self)!,
-                analytics: r.resolve(CoreAnalytics.self)!
+                analytics: r.resolve(CoreAnalytics.self)!,
+                config: r.resolve(ConfigProtocol.self)!
             )
         }
         


### PR DESCRIPTION
On Logistration Bottom View did not check if SSO was enabled or not. Because of this, the ‘Sign in with SSO’ button was displayed in the start view even with SSO disabled:
<img width="300" src="https://github.com/user-attachments/assets/5e1e0f45-9440-476c-a046-00ed3ec67db5">

 