### PR TITLE
fix: course download helper tests

### DIFF
--- a/Course/CourseTests/Presentation/Container/CourseDownloadHelperTests.swift
+++ b/Course/CourseTests/Presentation/Container/CourseDownloadHelperTests.swift
@@ -42,7 +42,7 @@ final class CourseDownloadHelperTests: XCTestCase {
             encodedVideo: .init(
                 fallback: nil,
                 youtube: nil,
-                desktopMP4: .init(url: "http://test/test.mp4", fileSize: 1000, streamPriority: 1),
+                desktopMP4: .init(url: "http://test/test.mp4", fileSize: 1000, streamPriority: 1, type: .desktopMP4),
                 mobileHigh: nil,
                 mobileLow: nil,
                 hls: nil


### PR DESCRIPTION
Fix the missed parameter in the CourseDownloadHelperTests.

<img width="342" alt="image" src="https://github.com/user-attachments/assets/ae56957e-4322-4e23-84c3-c0beb06b2dfe" />
