### PR TITLE
feat: fix sign in position on discovery view

### DIFF
--- a/Discovery/Discovery/Presentation/NativeDiscovery/DiscoveryView.swift
+++ b/Discovery/Discovery/Presentation/NativeDiscovery/DiscoveryView.swift
@@ -161,6 +161,7 @@ public struct DiscoveryView: View {
                             viewModel.router.showLoginScreen(sourceScreen: .discovery)
                         }
                     }
+                    .frame(maxHeight: .infinity, alignment: .bottom)
                 }
             }.padding(.top, 8)
 


### PR DESCRIPTION
before:
![Simulator Screenshot - iPhone 16 Pro - 2025-03-27 at 17 27 52](https://github.com/user-attachments/assets/06e3ff82-a2cb-449c-abe4-4cba4cad28ae)

after:
![Simulator Screenshot - iPhone 16 Pro - 2025-03-27 at 17 29 12](https://github.com/user-attachments/assets/e7b2692a-d67c-4ef9-b5d5-60d3b12171a6)
