### PR TITLE
build: fix workflow issues

### DIFF
--- a/ci_scripts/ci_prepare_env.sh
+++ b/ci_scripts/ci_prepare_env.sh
@@ -35,7 +35,7 @@ install_xcode_cloud_brew_dependencies () {
 }
 
 setup_github_actions_environment() {
-    brew update && brew install xcodegen xcodesorg/made/xcodes git-lfs
+    brew update && brew install xcodegen git-lfs
     
     bundle config path vendor/bundle
     bundle install --jobs 4 --retry 3


### PR DESCRIPTION
### Summary
Fixes CI failure by removing the explicit installation of the `xcodes` package via Homebrew. The macOS runner already includes `xcodes`, and the manual installation was causing conflicts with the pre-installed version.