### PR TITLE
feat: course progress page issues

### DIFF
--- a/Authorization/Authorization.xcodeproj/project.pbxproj
+++ b/Authorization/Authorization.xcodeproj/project.pbxproj
@@ -526,9 +526,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App-Authorization-AuthorizationTests/Pods-App-Authorization-AuthorizationTests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App-Authorization-AuthorizationTests/Pods-App-Authorization-AuthorizationTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1605,7 +1609,7 @@
 			repositoryURL = "https://github.com/openedx/openedx-app-foundation-ios/";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.3;
+				version = 1.0.4;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -155,7 +155,6 @@
 		CE38BBD72D9D8294002CD276 /* ExperimentalFeaturesConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE38BBD62D9D8294002CD276 /* ExperimentalFeaturesConfig.swift */; };
 		CE54C2D22CC80D8500E529F9 /* DownloadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE54C2D12CC80D8500E529F9 /* DownloadManagerTests.swift */; };
 		CE57127C2CD109DB00D4AB17 /* OEXFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = CE57127B2CD109DB00D4AB17 /* OEXFoundation */; };
-		CE5BBFF42E24236500D51C92 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5BBFF32E24236500D51C92 /* ColorExtension.swift */; };
 		CE7CAF392CC1561E00E0AC9D /* OEXFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = CE7CAF382CC1561E00E0AC9D /* OEXFoundation */; };
 		CE84CE242E38F57A0095C9C3 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE84CE232E38F57A0095C9C3 /* ColorExtension.swift */; };
 		CE953A3B2CD0DA940023D667 /* CoreMock.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE953A3A2CD0DA940023D667 /* CoreMock.generated.swift */; };
@@ -1084,9 +1083,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App-Core-CoreTests/Pods-App-Core-CoreTests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App-Core-CoreTests/Pods-App-Core-CoreTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -2375,7 +2375,7 @@
 			repositoryURL = "https://github.com/openedx/openedx-app-foundation-ios/";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.3;
+				version = 1.0.4;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Core/Core/Extensions/ColorExtension.swift
+++ b/Core/Core/Extensions/ColorExtension.swift
@@ -5,7 +5,7 @@
 //  Created by Ivan Stepanok on 13.07.2025.
 //
 
-import SwiftUICore
+import SwiftUI
 
 public extension Color {
     init?(hex: String) {

--- a/Course/Course.xcodeproj/project.pbxproj
+++ b/Course/Course.xcodeproj/project.pbxproj
@@ -2238,7 +2238,7 @@
 			repositoryURL = "https://github.com/openedx/openedx-app-foundation-ios/";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.3;
+				version = 1.0.4;
 			};
 		};
 		CEBCA4322CC13CDE00076589 /* XCRemoteSwiftPackageReference "YouTubePlayerKit" */ = {

--- a/Course/Course/Presentation/Content/CourseContentView.swift
+++ b/Course/Course/Presentation/Content/CourseContentView.swift
@@ -120,7 +120,7 @@ public struct CourseContentView: View {
                     VStack(spacing: 18) {
                         Divider()
                         Button(action: {
-    //                        viewModel.selection = 0
+                            viewModel.selection = 2
                         }, label: {
                         HStack(spacing: 4) {
                             CoreAssets.gallery.swiftUIImage.renderingMode(.template)

--- a/Course/Course/Presentation/Content/Elements/AssignmentCardSmallView.swift
+++ b/Course/Course/Presentation/Content/Elements/AssignmentCardSmallView.swift
@@ -115,7 +115,7 @@ struct AssignmentCardSmallView: View {
                 RoundedRectangle(cornerRadius: 4)
                     .stroke(
                         strokeColor,
-                        lineWidth: isSelected ? 2 : 1
+                        lineWidth: isSelected ? 4 : 1
                     )
             )
             .cornerRadius(4)

--- a/Course/Course/Presentation/Content/Elements/ProgressAssignmentTypeSection.swift
+++ b/Course/Course/Presentation/Content/Elements/ProgressAssignmentTypeSection.swift
@@ -103,10 +103,11 @@ struct ProgressAssignmentTypeSection: View {
 
             // MARK: – Detail Card
             if selectedIndex < filteredSubsections.count {
+                let ui = filteredSubsections[selectedIndex]
                 AssignmentDetailCardView(
                     detailData: AssignmentDetailData(
-                        subsectionUI: filteredSubsections[selectedIndex],
-                        sectionName: sectionName,
+                        subsectionUI: ui,
+                        sectionName: parentSectionName(for: ui),
                         onAssignmentTap: onAssignmentTap
                     )
                 )
@@ -137,6 +138,19 @@ struct ProgressAssignmentTypeSection: View {
             selectedIndex = 0
             uiScrollView?.setContentOffset(.zero, animated: animated)
         }
+    }
+
+    private func parentSectionName(for ui: CourseProgressSubsectionUI) -> String {
+        guard let structure = sectionData.courseStructure else { return sectionName }
+        let blockKey = ui.subsection.blockKey
+        for chapter in structure.childs {
+            for sequential in chapter.childs {
+                if sequential.blockId == blockKey || sequential.id == blockKey {
+                    return chapter.displayName
+                }
+            }
+        }
+        return sectionName
     }
 }
 
@@ -214,7 +228,8 @@ struct ProgressAssignmentTypeSection: View {
                 )
                 ],
                 sectionName: "Labs",
-                assignmentTypeColors: [:]
+                assignmentTypeColors: [:],
+                courseStructure: nil
             ),
             proxy: proxy,
             onAssignmentTap: { _ in },

--- a/Course/Course/Presentation/Content/Elements/ProgressAssignmentTypeSection.swift
+++ b/Course/Course/Presentation/Content/Elements/ProgressAssignmentTypeSection.swift
@@ -85,7 +85,7 @@ struct ProgressAssignmentTypeSection: View {
                 }
                 .accessibilityIdentifier("assignment_cards_horizontal_scroll_\(sectionName)")
 
-                .introspect(.scrollView, on: .iOS(.v16, .v17, .v18)) { scroll in
+                .introspect(.scrollView, on: .iOS(.v16, .v17, .v18, .v26)) { scroll in
                     DispatchQueue.main.async { uiScrollView = scroll }
                 }
 

--- a/Course/Course/Presentation/Content/Elements/VideoSectionView.swift
+++ b/Course/Course/Presentation/Content/Elements/VideoSectionView.swift
@@ -121,7 +121,7 @@ struct VideoSectionView: View {
                             }
                         }
                     }
-                    .introspect(.scrollView, on: .iOS(.v16, .v17, .v18)) { scroll in
+                    .introspect(.scrollView, on: .iOS(.v16, .v17, .v18, .v26)) { scroll in
                         DispatchQueue.main.async {
                             uiScrollView = scroll
                         }

--- a/Course/Course/Presentation/Content/Elements/VideoSectionView.swift
+++ b/Course/Course/Presentation/Content/Elements/VideoSectionView.swift
@@ -116,7 +116,7 @@ struct VideoSectionView: View {
                                 .id(video.id)
                                 
                                 if index == visibleVideos.count - 1 {
-                                    Spacer(minLength: 100)
+                                    Spacer(minLength: 500)
                                 }
                             }
                         }
@@ -162,7 +162,7 @@ struct VideoSectionView: View {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             guard let scroll = uiScrollView else { return }
-            let newX = max(scroll.contentOffset.x - 20, 0)
+            let newX = max(scroll.contentOffset.x - 16, 0)
             scroll.setContentOffset(CGPoint(x: newX, y: 0), animated: true)
         }
     }

--- a/Course/Course/Presentation/Content/Elements/VideoThumbnailView.swift
+++ b/Course/Course/Presentation/Content/Elements/VideoThumbnailView.swift
@@ -78,6 +78,19 @@ struct VideoThumbnailView: View {
                     .clipped()
                     .cornerRadius(10)
                 
+                // Gradient overlay to improve title readability
+                LinearGradient(
+                    colors: [
+                        Color.black.opacity(0.5),
+                        Color.black.opacity(0.0),
+                        Color.black.opacity(0.0),
+                        Color.black.opacity(0.0)
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .cornerRadius(10)
+                
                 Text(video.displayName)
                     .lineLimit(2)
                     .font(Theme.Fonts.bodySmall)
@@ -137,7 +150,7 @@ struct VideoThumbnailView: View {
                     // Show local progress bar when rewatching
                     ZStack(alignment: .leading) {
                         Rectangle()
-                            .fill(Color.gray.opacity(0.3))
+                            .fill(Theme.Colors.primaryCardProgressBG)
                             .frame(height: 4)
                             .cornerRadius(2)
                             .padding(.horizontal, 4)
@@ -167,7 +180,7 @@ struct VideoThumbnailView: View {
             // Partially watched - show progress bar
             ZStack(alignment: .leading) {
                 Rectangle()
-                    .fill(Color.gray.opacity(0.3))
+                    .fill(Theme.Colors.primaryCardProgressBG)
                     .frame(height: 4)
                     .cornerRadius(2)
                     .padding(.horizontal, 4)

--- a/Course/Course/Presentation/Content/Models/AssignmentContentData.swift
+++ b/Course/Course/Presentation/Content/Models/AssignmentContentData.swift
@@ -32,6 +32,7 @@ struct AssignmentSectionData {
     let subsectionsUI: [CourseProgressSubsectionUI]
     let sectionName: String
     let assignmentTypeColors: [String: String]
+    let courseStructure: CourseStructure?
 }
 
 struct AssignmentDetailData {

--- a/Course/Course/Presentation/Content/Subviews/AssignmentsContentView.swift
+++ b/Course/Course/Presentation/Content/Subviews/AssignmentsContentView.swift
@@ -164,7 +164,10 @@ struct AssignmentsContentView: View {
                                                     sectionData: AssignmentSectionData(
                                                         subsectionsUI: section.subsections,
                                                         sectionName: section.key,
-                                                        assignmentTypeColors: assignmentContentData.assignmentTypeColors
+                                                        assignmentTypeColors: assignmentContentData
+                                                            .assignmentTypeColors,
+                                                        courseStructure: assignmentContentData
+                                                            .courseAssignmentsStructure
                                                     ),
                                                     proxy: proxy,
                                                     onAssignmentTap: onAssignmentTap,
@@ -172,11 +175,11 @@ struct AssignmentsContentView: View {
                                                 )
                                                 Divider()
                                             }
-                                        .accessibilityElement(children: .contain)
-                                        .accessibilityLabel(
-                                            "\(section.key) \(CourseLocalization.Accessibility.assignmentsSection)"
-                                        )
-                                    }
+                                            .accessibilityElement(children: .contain)
+                                            .accessibilityLabel(
+                                                "\(section.key) \(CourseLocalization.Accessibility.assignmentsSection)"
+                                            )
+                                        }
                                 }
                             }
                         }

--- a/Course/Course/Presentation/Progress/CourseProgressScreenView.swift
+++ b/Course/Course/Presentation/Progress/CourseProgressScreenView.swift
@@ -52,7 +52,7 @@ struct CourseProgressScreenView: View {
                         }
                     } else {
                         ScrollView {
-                            VStack(alignment: .center, spacing: 20) {
+                            VStack(alignment: .center) {
                                 DynamicOffsetView(
                                     coordinate: $coordinate,
                                     collapsed: $collapsed,
@@ -118,10 +118,10 @@ struct CourseProgressScreenView: View {
     
     @ViewBuilder
     private var courseProgressContent: some View {
-        VStack(alignment: .leading, spacing: 32) {
+        VStack(alignment: .leading, spacing: 16) {
             if viewModel.courseProgress != nil {
                 // Course Completion Header Section
-                VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 0) {
                     HStack(alignment: .top, spacing: 16) {
                         VStack(alignment: .leading, spacing: 8) {
                             Text(CourseLocalization.CourseContainer.Progress.title)
@@ -151,7 +151,7 @@ struct CourseProgressScreenView: View {
                         .accessibilityAddTraits(.updatesFrequently)
                     }
                 }
-                .padding(.top, 16)
+//                .padding(.top, 16)
                 
                 // Check if course has graded assignments
                 if viewModel.hasGradedAssignments {

--- a/Course/Course/SwiftGen/Strings.swift
+++ b/Course/Course/SwiftGen/Strings.swift
@@ -169,9 +169,9 @@ public enum CourseLocalization {
     public static func dueWithDate(_ p1: Any, _ p2: Any) -> String {
       return CourseLocalization.tr("Localizable", "ASSIGNMENT_STATUS.DUE_WITH_DATE", String(describing: p1), String(describing: p2), fallback: "%@ %@")
     }
-    /// %@ In Progress - %@/%@ points
+    /// %@ - %@/%@ points
     public static func inProgress(_ p1: Any, _ p2: Any, _ p3: Any) -> String {
-      return CourseLocalization.tr("Localizable", "ASSIGNMENT_STATUS.IN_PROGRESS", String(describing: p1), String(describing: p2), String(describing: p3), fallback: "%@ In Progress - %@/%@ points")
+      return CourseLocalization.tr("Localizable", "ASSIGNMENT_STATUS.IN_PROGRESS", String(describing: p1), String(describing: p2), String(describing: p3), fallback: "%@ - %@/%@ points")
     }
     /// %@ Not Yet Available
     public static func notYetAvailable(_ p1: Any) -> String {

--- a/Course/Course/en.lproj/Localizable.strings
+++ b/Course/Course/en.lproj/Localizable.strings
@@ -221,7 +221,7 @@
 "ASSIGNMENT_STATUS.COMPLETE" = "%@ Complete - %@/%@ points";
 "ASSIGNMENT_STATUS.PAST_DUE" = "%@ Past Due - %@/%@ points";
 "ASSIGNMENT_STATUS.NOT_YET_AVAILABLE" = "%@ Not Yet Available";
-"ASSIGNMENT_STATUS.IN_PROGRESS" = "%@ In Progress - %@/%@ points";
+"ASSIGNMENT_STATUS.IN_PROGRESS" = "%@ - %@/%@ points";
 "ASSIGNMENT_STATUS.DUE_WITH_DATE" = "%@ %@";
 
 "ASSIGNMENT.REVIEW_GRADING_POLICY" = "Review Course Grading Policy";

--- a/Dashboard/Dashboard.xcodeproj/project.pbxproj
+++ b/Dashboard/Dashboard.xcodeproj/project.pbxproj
@@ -477,9 +477,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App-Dashboard-DashboardTests/Pods-App-Dashboard-DashboardTests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App-Dashboard-DashboardTests/Pods-App-Dashboard-DashboardTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1539,7 +1543,7 @@
 			repositoryURL = "https://github.com/openedx/openedx-app-foundation-ios/";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.3;
+				version = 1.0.4;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Discovery/Discovery.xcodeproj/project.pbxproj
+++ b/Discovery/Discovery.xcodeproj/project.pbxproj
@@ -518,9 +518,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App-Discovery-DiscoveryUnitTests/Pods-App-Discovery-DiscoveryUnitTests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App-Discovery-DiscoveryUnitTests/Pods-App-Discovery-DiscoveryUnitTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1623,7 +1627,7 @@
 			repositoryURL = "https://github.com/openedx/openedx-app-foundation-ios/";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.3;
+				version = 1.0.4;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Discussion/Discussion.xcodeproj/project.pbxproj
+++ b/Discussion/Discussion.xcodeproj/project.pbxproj
@@ -668,9 +668,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App-Discussion-DiscussionTests/Pods-App-Discussion-DiscussionTests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App-Discussion-DiscussionTests/Pods-App-Discussion-DiscussionTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1804,7 +1808,7 @@
 			repositoryURL = "https://github.com/openedx/openedx-app-foundation-ios/";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.3;
+				version = 1.0.4;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Downloads/Downloads.xcodeproj/project.pbxproj
+++ b/Downloads/Downloads.xcodeproj/project.pbxproj
@@ -434,9 +434,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App-Downloads-DownloadsTests/Pods-App-Downloads-DownloadsTests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App-Downloads-DownloadsTests/Pods-App-Downloads-DownloadsTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1590,7 +1594,7 @@
 			repositoryURL = "https://github.com/openedx/openedx-app-foundation-ios/";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.3;
+				version = 1.0.4;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/OpenEdX.xcodeproj/project.pbxproj
+++ b/OpenEdX.xcodeproj/project.pbxproj
@@ -1255,7 +1255,7 @@
 			repositoryURL = "https://github.com/openedx/openedx-app-foundation-ios/";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.3;
+				version = 1.0.4;
 			};
 		};
 		CEBA52752CEBB69100619E2B /* XCRemoteSwiftPackageReference "openedx-app-firebase-analytics-ios" */ = {

--- a/Profile/Profile.xcodeproj/project.pbxproj
+++ b/Profile/Profile.xcodeproj/project.pbxproj
@@ -671,9 +671,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App-Profile-ProfileTests/Pods-App-Profile-ProfileTests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App-Profile-ProfileTests/Pods-App-Profile-ProfileTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1748,7 +1752,7 @@
 			repositoryURL = "https://github.com/openedx/openedx-app-foundation-ios/";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.3;
+				version = 1.0.4;
 			};
 		};
 		CEBCA42F2CC13CB900076589 /* XCRemoteSwiftPackageReference "ios-branch-sdk-spm" */ = {

--- a/WhatsNew/WhatsNew.xcodeproj/project.pbxproj
+++ b/WhatsNew/WhatsNew.xcodeproj/project.pbxproj
@@ -418,9 +418,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App-WhatsNew-WhatsNewTests/Pods-App-WhatsNew-WhatsNewTests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-App-WhatsNew-WhatsNewTests/Pods-App-WhatsNew-WhatsNewTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1532,7 +1536,7 @@
 			repositoryURL = "https://github.com/openedx/openedx-app-foundation-ios/";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.3;
+				version = 1.0.4;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
Fixes for https://github.com/openedx/openedx-app-ios/issues/603 https://github.com/openedx/openedx-app-ios/issues/611

✅ The assignment cards should have the section name as the top line. Currently displaying assignment type.
<img width="544" height="166" alt="Screenshot 2025-09-22 at 11 35 18" src="https://github.com/user-attachments/assets/22a0b799-91fa-4d98-a143-be60aef3989e" />

✅ Increase stroke assignment code thumbs (ie: HW1 rectangle). For selected state (blue border) increase more. States should appear as below:
<img width="327" height="116" alt="Screenshot 2025-09-22 at 11 35 26" src="https://github.com/user-attachments/assets/12d34f96-51ce-4f9e-8e53-d1f930261da3" />

✅ For iPhone, the "Review Course Grading Policy" button doesn't work many of the times.

✅ Progress page. Can we reduce the padding from "Course Completion" header to match other pages?
<img width="585" height="466" alt="Screenshot 2025-09-22 at 11 35 56" src="https://github.com/user-attachments/assets/ffbf949d-b115-48ad-ac5f-4836f98f7220" />

✅ For assignments with no due date, instead of "XX In Progress - 0/1 points" text should just be "XX - 0/1 points" where XX is the assignment code. For HW4, for example, bottom line should read "HW4 - 0/1 points"
<img width="544" height="270" alt="Screenshot 2025-09-22 at 11 36 08" src="https://github.com/user-attachments/assets/a6f3b77a-0a33-42c1-8ee8-c0da3b8019c9" />

✅ If there is only two videos in a section, the completed videos are not scrolled correctly. In the screenshot below, Section 4 should have the first unwatched video scrolled aligned to the section header as in Section 2
<img width="580" height="560" alt="Screenshot 2025-09-22 at 11 36 26" src="https://github.com/user-attachments/assets/724d5e9e-f0d2-480f-ae04-4ed4465c84c1" />

✅ Video cards text is sometimes unreadable. with light text on certain background. Can we add a gradient
✅ For progress bar: can we change the bar to a solid fill instead of a transparent for visibility?
<img width="582" height="267" alt="Screenshot 2025-09-22 at 11 37 06" src="https://github.com/user-attachments/assets/91276fb1-eb8d-480e-813e-a8f5cf4244f0" />


