### PR TITLE
fix: removed lazy views due to iOS 26 bug

### DIFF
--- a/Course/Course/Presentation/Unit/Subviews/UnitStack.swift
+++ b/Course/Course/Presentation/Unit/Subviews/UnitStack.swift
@@ -35,17 +35,15 @@ public struct UnitStack<Content>: View where Content: View {
 
     public var body: some View {
         if isVerticalNavigation {
-            LazyVStack(
+            VStack(
                 alignment: alignment.verticalAlignment,
                 spacing: spacing,
-                pinnedViews: pinnedViews,
                 content: content
             )
         } else {
-            LazyHStack(
+            HStack(
                 alignment: alignment.horizontalAlignment,
                 spacing: spacing,
-                pinnedViews: pinnedViews,
                 content: content
             )
         }


### PR DESCRIPTION
**Problem:**
Previously, LazyVStack and LazyHStack did not cache their content properly, which caused course blocks to disappear during navigation.

**Solution:**
The solution is to replace LazyVStack and LazyHStack with regular VStack and HStack to  prevent content loss.