### PR TITLE
Fixes:  Assignment thumbnails  count, color coding for assignments in progress, word “Sections” was missing

### DIFF
--- a/Course/Course/Presentation/Container/CourseContainerViewModel.swift
+++ b/Course/Course/Presentation/Container/CourseContainerViewModel.swift
@@ -1362,18 +1362,25 @@ public final class CourseContainerViewModel: BaseCourseViewModel {
             .first { $0.type == assignmentType }?
             .type
     }
-    
+
     func assignmentTypeColor(for assignmentType: String) -> String? {
         guard let progressDetails = courseProgressDetails else { return nil }
-        
-        if let index = progressDetails.gradingPolicy.assignmentPolicies
-            .firstIndex(where: { $0.type == assignmentType }) {
-            let colors = progressDetails.gradingPolicy.assignmentColors
-            return index < colors.count ? colors[index] : nil
+
+        guard let index = progressDetails.gradingPolicy.assignmentPolicies
+            .firstIndex(where: { $0.type == assignmentType }) else {
+            return nil
         }
-        return nil
+
+        let colors = progressDetails.gradingPolicy.assignmentColors
+
+        guard !colors.isEmpty else { return nil }
+
+        let colorIndex = index % colors.count
+        let hexColor = colors[colorIndex]
+
+        return hexColor
     }
-    
+
     func getSequentialShortLabel(for blockKey: String) -> String? {
         guard let courseStructure = courseAssignmentsStructure ?? courseStructure else { return nil }
         

--- a/Course/Course/Presentation/Content/Subviews/AllContentView.swift
+++ b/Course/Course/Presentation/Content/Subviews/AllContentView.swift
@@ -74,7 +74,10 @@ struct AllContentView: View {
                                 // MARK: Course Progress
                                 if let progress = viewModel.courseProgress(),
                                    let total = progress.totalAssignmentsCount, total > 0 {
-                                    CourseProgressView(progress: progress)
+                                    CourseProgressView(
+                                        progress: progress,
+                                        isSections: true
+                                    )
                                         .padding(.horizontal, 24)
                                         .accessibilityElement(children: .combine)
                                         .accessibilityLabel(CourseLocalization.Accessibility.courseProgressSection)

--- a/Course/Course/Presentation/Content/Subviews/AllContentView.swift
+++ b/Course/Course/Presentation/Content/Subviews/AllContentView.swift
@@ -76,7 +76,7 @@ struct AllContentView: View {
                                    let total = progress.totalAssignmentsCount, total > 0 {
                                     CourseProgressView(
                                         progress: progress,
-                                        isSections: true
+                                        fromAllContentTab: true
                                     )
                                         .padding(.horizontal, 24)
                                         .accessibilityElement(children: .combine)

--- a/Course/Course/Presentation/Content/Subviews/AssignmentsContentView.swift
+++ b/Course/Course/Presentation/Content/Subviews/AssignmentsContentView.swift
@@ -133,7 +133,6 @@ struct AssignmentsContentView: View {
                                                         )
                                                     
                                                     Spacer()
-                                                    
                                                     let weightColor = Color(
                                                         hex: assignmentContentData.assignmentTypeColors[section.key]
                                                         ?? "#666666"

--- a/Course/Course/Presentation/Subviews/CourseCarouselView/CourseGradeCarouselSlideView.swift
+++ b/Course/Course/Presentation/Subviews/CourseCarouselView/CourseGradeCarouselSlideView.swift
@@ -87,7 +87,7 @@ struct CourseGradeCarouselSlideView: View {
 
         return LazyVGrid(columns: columns, spacing: 16) {
             ForEach(
-                Array(viewModelProgress.assignmentPolicies.prefix(4).enumerated()),
+                Array(viewModelProgress.assignmentPolicies.enumerated()),
                 id: \.element.type
             ) { index, policy in
                 let progressData = viewModelProgress.getAssignmentProgress(

--- a/Course/Course/Presentation/Subviews/CourseProgressView.swift
+++ b/Course/Course/Presentation/Subviews/CourseProgressView.swift
@@ -17,7 +17,7 @@ public struct CourseProgressView: View {
     private var onShowCompletedAnalytics: (() -> Void)?
     private var showCompletedText = true
     private var progressPercentageCount = 0
-    private var isSections = false
+    private var fromAllContentTab = false
 
     public init(
         progress: CourseProgress,
@@ -26,7 +26,7 @@ public struct CourseProgressView: View {
         onToggleCompleted: (() -> Void)? = nil,
         onShowCompletedAnalytics: (() -> Void)? = nil,
         showCompletedText: Bool = true,
-        isSections: Bool = false
+        fromAllContentTab: Bool = false
     ) {
         self.progress = progress
         self.showCompletedToggle = showCompletedToggle
@@ -34,7 +34,7 @@ public struct CourseProgressView: View {
         self.onToggleCompleted = onToggleCompleted
         self.onShowCompletedAnalytics = onShowCompletedAnalytics
         self.showCompletedText = showCompletedText
-        self.isSections = isSections
+        self.fromAllContentTab = fromAllContentTab
     }
     
     public var body: some View {
@@ -82,7 +82,7 @@ public struct CourseProgressView: View {
                                     total
                                 )
                             : (
-                                !isSections ? CourseLocalization.Course.progressCompleted(
+                                !fromAllContentTab ? CourseLocalization.Course.progressCompleted(
                                     completed,
                                     total
                                 ) : CourseLocalization.Course.progressSectionsCompleted(

--- a/Course/Course/Presentation/Subviews/CourseProgressView.swift
+++ b/Course/Course/Presentation/Subviews/CourseProgressView.swift
@@ -17,6 +17,7 @@ public struct CourseProgressView: View {
     private var onShowCompletedAnalytics: (() -> Void)?
     private var showCompletedText = true
     private var progressPercentageCount = 0
+    private var isSections = false
 
     public init(
         progress: CourseProgress,
@@ -24,7 +25,8 @@ public struct CourseProgressView: View {
         isShowingCompleted: Bool = true,
         onToggleCompleted: (() -> Void)? = nil,
         onShowCompletedAnalytics: (() -> Void)? = nil,
-        showCompletedText: Bool = true
+        showCompletedText: Bool = true,
+        isSections: Bool = false
     ) {
         self.progress = progress
         self.showCompletedToggle = showCompletedToggle
@@ -32,6 +34,7 @@ public struct CourseProgressView: View {
         self.onToggleCompleted = onToggleCompleted
         self.onShowCompletedAnalytics = onShowCompletedAnalytics
         self.showCompletedText = showCompletedText
+        self.isSections = isSections
     }
     
     public var body: some View {
@@ -71,9 +74,22 @@ public struct CourseProgressView: View {
                 if showCompletedText {
                     if let total = progress.totalAssignmentsCount,
                        let completed = progress.assignmentsCompleted {
-                        Text(showCompletedToggle
-                             ? CourseLocalization.Course.progressVideosCompleted(completed, total)
-                             : CourseLocalization.Course.progressCompleted(completed, total)
+                        Text(
+                            showCompletedToggle
+                            ? CourseLocalization.Course
+                                .progressVideosCompleted(
+                                    completed,
+                                    total
+                                )
+                            : (
+                                !isSections ? CourseLocalization.Course.progressCompleted(
+                                    completed,
+                                    total
+                                ) : CourseLocalization.Course.progressSectionsCompleted(
+                                    completed,
+                                    total
+                                )
+                            )
                         )
                         .foregroundColor(Theme.Colors.textPrimary)
                         .font(Theme.Fonts.labelMedium)

--- a/Course/Course/SwiftGen/Strings.swift
+++ b/Course/Course/SwiftGen/Strings.swift
@@ -249,6 +249,10 @@ public enum CourseLocalization {
     }
     /// Hide Completed
     public static let progressHideCompleted = CourseLocalization.tr("Localizable", "COURSE.PROGRESS_HIDE_COMPLETED", fallback: "Hide Completed")
+    /// %@/%@ Sections Completed
+    public static func progressSectionsCompleted(_ p1: Any, _ p2: Any) -> String {
+      return CourseLocalization.tr("Localizable", "COURSE.PROGRESS_SECTIONS_COMPLETED", String(describing: p1), String(describing: p2), fallback: "%@/%@ Sections Completed")
+    }
     /// %@/%@ Completed
     public static func progressVideosCompleted(_ p1: Any, _ p2: Any) -> String {
       return CourseLocalization.tr("Localizable", "COURSE.PROGRESS_VIDEOS_COMPLETED", String(describing: p1), String(describing: p2), fallback: "%@/%@ Completed")

--- a/Course/Course/en.lproj/Localizable.strings
+++ b/Course/Course/en.lproj/Localizable.strings
@@ -183,6 +183,7 @@
 "COURSE.DUE_TOMORROW" = "Due Tomorrow";
 
 "COURSE.PROGRESS_COMPLETED" = "%@/%@ Completed";
+"COURSE.PROGRESS_SECTIONS_COMPLETED" = "%@/%@ Sections Completed";
 "COURSE.PROGRESS_VIDEOS_COMPLETED" = "%@/%@ Completed";
 "COURSE.PROGRESS_WATCHED" = "%@/%@ Watched";
 "COURSE.PROGRESS_VIEW_COMPLETED" = "View Completed";


### PR DESCRIPTION
Fixes for:
1. Word “Sections” was missing in the “1/2 Sections Completed” text under the main Progress bar on the Content page, All tab
2. Limited number of Assignment thumbnails were displayed on the Carousel, Grades tab.
3. Color coding did not applied on, default color shown for percentage badge when looping Assignment types in Content page, Assignments tab. 