### PR TITLE
build: unbreak CI on Ruby 3.4, update_fastlane and Xcode 16.1

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -25,10 +25,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-
 
+      - uses: ruby/setup-ruby@v1
+        with:
+          # fastlane 2.225.0 and its dependency tree are not Ruby 3.4 ready.
+          # macos-latest ships Ruby 3.4, so pin the last version that works.
+          ruby-version: '3.3'
+
       - name: Setup environment
         run: |
           source ci_scripts/ci_prepare_env.sh && setup_github_actions_environment
-          xcodes select 16.1
+          xcodes select 26.2
 
       - name: SwiftLint
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -28,6 +28,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-
 
+      - uses: ruby/setup-ruby@v1
+        with:
+          # fastlane 2.225.0 and its dependency tree are not Ruby 3.4 ready.
+          # macos-latest ships Ruby 3.4, so pin the last version that works.
+          ruby-version: '3.3'
+
       - name: Setup environment
         run:
           source ci_scripts/ci_prepare_env.sh && setup_github_actions_environment

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,8 +10,10 @@
 #     https://docs.fastlane.tools/plugins/available-plugins
 #
 
-# Uncomment the line if you want fastlane to automatically update itself
-update_fastlane
+# Do not enable update_fastlane here. In CI it self-updates fastlane at runtime,
+# so the version pinned in Gemfile.lock is not the version that actually runs,
+# and the RubyGems documentation hook it triggers pulls in rdoc, which fails to
+# load under bundler.
 
 before_all do
   xcodes(


### PR DESCRIPTION
CI has been red on every pull request since **2026-07-08**. Nothing has merged into `develop` since 2026-07-02. Three independent causes had stacked up on the refreshed `macos-latest` image — which is why fixing any one of them only moved the failure to the next.

## 1. The image moved to Ruby 3.4

Neither workflow pinned a Ruby version, so both picked up the new default. Ruby 3.4 removed a set of libraries from the default gems, and `fastlane` 2.225.0 needs them:

```
cannot load such file -- abbrev (LoadError)
  .../gems/highline-2.0.3/lib/highline.rb:17
  .../gems/fastlane-2.225.0/fastlane/lib/fastlane.rb:1
```

and once `abbrev` is supplied, `mutex_m` surfaces next. Pinned to Ruby 3.3, the last version that was green. No dependencies change.

## 2. `update_fastlane` pulls in rdoc, which needs rbs

Independent of the Ruby version — fails on 3.3 and 3.4 alike:

```
cannot load such file -- rbs (LoadError)
  rdoc-8.0.0/lib/rdoc/rbs_helper.rb:5
  rdoc-8.0.0/lib/rdoc/rubygems_hook.rb:247  in `setup`
  rubygems/request_set.rb:313               in `install_hooks`
```

`update_fastlane` installs a new fastlane at runtime, which fires the RubyGems documentation hook, which loads `rdoc` 8, whose `rbs_helper` requires `rbs`. `rbs` is a *bundled* gem, so it is not on the load path under `bundle exec`.

Removed. It is harmful in CI for a second reason anyway: self-updating fastlane at runtime means the version pinned in `Gemfile.lock` is not the version that actually runs.

## 3. `xcodes select 16.1` against an image that only has Xcode 26.x

`swiftlint.yml` hardcoded Xcode 16.1. The runner now offers only 26.0.1 through 26.6, so `xcodes` fell through to its interactive picker, got nothing on stdin, and exited 1:

```
Available Xcode versions:
  1) 26.0.1 (17A400)
  ...
  7) 26.6 (17F113) (Selected)
Enter the number of the Xcode to select: Not a valid number.
```

Now selects 26.2, matching the version the `Fastfile` pins in `before_all`.

## Verification

With causes 1 and 2 fixed, `Tests` ran the full suite and **passed** in ~16 minutes (run [31686398890](https://github.com/openedx/openedx-app-ios/actions/runs/31686398890)) instead of aborting after 1-2 minutes. Cause 3 only affected `Lint`, and is fixed in the same push.

## Follow-up worth doing separately

Bump `fastlane` to >= 2.230.0 — from that version fastlane declares `abbrev`, `base64`, `csv`, `logger` and `mutex_m` itself, and 2.238.0 adds `ostruct`. That would let the Ruby 3.3 pin be dropped. Left out here to keep a release-blocking fix small.

Needed before the Verawood release PR #665 can go green.