### PR TITLE
build: grandfather pre-enforcement commit subjects in commitlint

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,68 @@
+// Open edX commit message linting.
+//
+// This is the default configuration from openedx/edx-lint
+// (edx_lint/files/commitlint.config.js), copied verbatim, plus one addition:
+// the GRANDFATHERED_HEADERS allow-list at the top of the `ignores` section.
+//
+// Keeping a repo-local copy is the documented override for
+// openedx/.github/.github/workflows/commitlint.yml, which downloads the shared
+// default only when this file is absent.
+
+// Squash-merge commits that landed on `develop` before conventional-commit
+// subjects were enforced on merge in this repo. These are published, immutable
+// history: they are reachable from `develop`, from release tags and from every
+// fork, so they cannot be corrected without rewriting shared history.
+//
+// Each entry is a complete, exact header line including its PR number. PR
+// numbers are never reused, so this list can only ever match these six specific
+// historical commits; no future commit can accidentally match it.
+//
+// Do not add entries here. Fix the commit subject instead.
+const GRANDFATHERED_HEADERS = new Set([
+  'Fixes:  Assignment thumbnails  count, color coding for assignments in progress, word “Sections” was missing (#649)',
+  'Fix: certificates not displayed after being earned (#651)',
+  'Replace SwiftMocky with Mockolo for test mocks generation (#652)',
+  'Migrate from ObservableObject to @Observable (Swift Observation) (#653)',
+  'Fix/issue 581 (#635)',
+  'Fix issues 640, 641, 652 (#661)',
+]);
+
+const Configuration = {
+  extends: ['@commitlint/config-conventional'],
+
+  helpUrl: 'https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html',
+
+  rules: {
+    'type-enum':
+      [2, 'always', [
+        'revert', 'feat', 'fix', 'perf', 'docs', 'test', 'build', 'refactor', 'style', 'chore', 'temp',
+      ]],
+
+    // Increase the header max length to account for PR numbers on squash merges
+    'header-max-length': [2, 'always', 110],
+
+    // Default rules we want to suppress:
+    'body-leading-blank': [0, "always"],
+    'body-max-line-length': [0, "always"],
+    'footer-max-line-length': [0, "always"],
+    'footer-leading-blank': [0, "always"],
+    'subject-case': [0, "always", []],
+    'subject-full-stop': [0, "never", '.'],
+  },
+
+  ignores: [
+    // Allow GitHub revert messages, like:
+    //    Revert "introduce a bug"
+    //    Revert "introduce a bug" (#1234)
+    message => /^Revert ".*"( \(#\d+\))?/.test(message),
+
+    // Pre-enforcement squash commits; see GRANDFATHERED_HEADERS above.
+    message => GRANDFATHERED_HEADERS.has(message.split('\n')[0]),
+
+    // BTW: commitlint has a built-in list of ignores which are also applied.
+    // Those include the typical "Merged" messages, so those are implicitly ignored:
+    // https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/is-ignored/src/defaults.ts
+  ],
+};
+
+export default Configuration;


### PR DESCRIPTION
Every release PR (`develop` → `main`) fails commitlint, including the one open right now — #665. This makes it pass without touching history, and without weakening enforcement for anything new.

## Cause

commitlint re-lints `develop` history that predates conventional subjects being enforced on merge. Six squash commits are involved, the oldest from May 2026:

| Commit | Header | Violations |
|---|---|---|
| `63590ab0` | `Fixes:  Assignment thumbnails  count, … (#649)` | `type-case`, `type-enum`, 114 > 110 |
| `1b4e9f3e` | `Fix: certificates not displayed after being earned (#651)` | `type-case`, `type-enum` |
| `0792ece8` | `Replace SwiftMocky with Mockolo for test mocks generation (#652)` | `type-empty`, `subject-empty` |
| `a8e722eb` | `Migrate from ObservableObject to @Observable (Swift Observation) (#653)` | `type-empty`, `subject-empty` |
| `c008b5fc` | `Fix/issue 581 (#635)` | `type-empty`, `subject-empty` |
| `beec3fb4` | `Fix issues 640, 641, 652 (#661)` | `type-empty`, `subject-empty` |

## Why these are not simply corrected

Rewriting them is a non-fast-forward update of `develop`, and `develop` has `allowsForcePushes: false` plus a required pull request — no force push is possible without an org admin. Even granted one, it would:

- strip the GitHub signatures from 12 currently-verified commits, which cannot be re-created;
- orphan 6 PRs from the generated release notes, since the generator maps commits to PRs by SHA — including the New Contributors section;
- leave 6 forks that are pinned into the rewritten range, where a plain `git pull` drags the old commits straight back with no conflict and no warning.

## What this does

The shared `openedx/.github` commitlint workflow downloads the default config **only when a repo-local `commitlint.config.mjs` is absent**:

```bash
if [[ ! -f commitlint.config.mjs ]]; then
  echo "Downloading the default commitlint config from edx_lint"
  wget --no-verbose -O commitlint.config.mjs <edx-lint default>
fi
```

So this file is the sanctioned override point. It is the upstream `openedx/edx-lint` config **verbatim**, plus one `ignores` predicate holding those six headers as exact strings, PR number included. The `ignores` mechanism is already used upstream for revert commits. PR numbers are never reused, so no future commit can match the list.

## Verification

Run against commitlint with the real `main..develop` range:

| Scenario | Result |
|---|---|
| With the predicate | **13/13 pass** |
| With the predicate removed | **exactly those 6 fail**, the other 7 still pass on their own merits |
| New offenders — `Fix: some new thing (#999)`, `Just some change (#999)`, `wip: …`, header > 110 | still rejected |
| Near misses — same text with a different PR number, without a PR number, lower-cased, or with a trailing space | still rejected |

## Follow-up

This treats the symptom. The cause is that `squash_merge_commit_title` is `COMMIT_OR_PR_TITLE`, so the **PR title** becomes the commit subject — while commitlint-github-action lints the PR's *branch* commits, which all passed in those six PRs. The string that actually lands on `develop` is linted nowhere, and the release PR is the first place it is ever checked, by which point it is immutable.

A separate PR will lint PR titles so this list never needs a seventh entry.
