### PR TITLE
build: lint the commit subject that squash merges will create

### DIFF
--- a/.github/workflows/commitlint-pr-title.yml
+++ b/.github/workflows/commitlint-pr-title.yml
@@ -1,0 +1,96 @@
+# Lint the commit subject that a squash merge will actually create.
+#
+# .github/workflows/commitlint.yml lints the commits on the pull request branch.
+# Those commits are not what lands on `develop`: this repo squash-merges, and
+# `squash_merge_commit_title` is COMMIT_OR_PR_TITLE, so GitHub composes the
+# subject as either the pull request title or, when the branch holds exactly one
+# commit, that commit's own subject — then appends " (#<number>)".
+#
+# Nothing lints that composed string today, so non-conventional subjects reach
+# `develop` through pull requests whose branch commits all passed. The release
+# pull request is the first place they are ever checked, by which point they are
+# immutable history.
+#
+# This job composes the same string and lints it with the same
+# commitlint.config.mjs the commit job uses, so one ruleset governs both.
+
+name: Lint PR Title
+
+on:
+  pull_request:
+    # `edited` is the essential trigger: a title can change at any time, including
+    # after every other check has gone green. `synchronize` re-runs when commits
+    # change, which matters because the single-commit branch below reads the head
+    # commit's subject.
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  pr-title:
+    name: Lint PR Title
+    # Release pull requests (develop -> main) land as merge commits, whose subject
+    # is GitHub's auto-generated "Merge pull request #N from ...". commitlint
+    # ignores those by default, so the release title never becomes a linted
+    # subject and checking it would be pure friction.
+    if: ${{ !(github.head_ref == 'develop' && github.base_ref == 'main') }}
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: commitlint-pr-title-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Depth 2 brings in both parents of the pull request merge ref, so the
+          # head commit is present for the single-commit case below. The default
+          # checkout is the merge ref itself, whose subject is "Merge <sha> into
+          # <sha>" — never the string we want.
+          fetch-depth: 2
+
+      - name: Install commitlint
+        # commitlint resolves `extends` relative to the directory holding the
+        # config, so @commitlint/config-conventional has to be installed beside
+        # commitlint.config.mjs at the repo root. Installing through
+        # `npx --package` puts it in the npx cache instead, where the resolver
+        # cannot see it, and every run fails with MODULE_NOT_FOUND.
+        #
+        # There is no root package.json, and --no-save writes neither one nor a
+        # lockfile, so this leaves only node_modules behind.
+        run: |
+          npm install --no-save --no-audit --no-fund \
+            @commitlint/cli@19.8.1 \
+            @commitlint/config-conventional@19.8.1
+
+      - name: Lint the squash commit subject
+        env:
+          # The title is untrusted input. Passing it through the environment
+          # rather than interpolating it into the script keeps it out of the
+          # shell's parse step.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_COMMITS: ${{ github.event.pull_request.commits }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Mirror COMMIT_OR_PR_TITLE. If the count is ever missing from the
+          # payload this falls through to the title, which is the behaviour of
+          # every multi-commit pull request and the common case.
+          if [ "${PR_COMMITS:-}" = "1" ]; then
+            SUBJECT=$(git log -1 --pretty=%s "$HEAD_SHA")
+            echo "Pull request has one commit; GitHub will use its subject."
+          else
+            SUBJECT=$PR_TITLE
+            echo "Pull request has ${PR_COMMITS:-?} commits; GitHub will use the title."
+          fi
+
+          echo "Linting: ${SUBJECT} (#${PR_NUMBER})"
+
+          # printf rather than echo: a subject beginning with "-" must reach
+          # commitlint on stdin as data, not be read as an option.
+          printf '%s (#%s)' "$SUBJECT" "$PR_NUMBER" \
+            | npx commitlint --config commitlint.config.mjs


### PR DESCRIPTION
#667 grandfathered six commit subjects on `develop` so release pull requests could go green. That treated the symptom. This closes the door they came through, so the list never needs a seventh entry.

## Cause

`.github/workflows/commitlint.yml` calls the shared `openedx/.github` workflow, which runs `wagoid/commitlint-github-action`. That action lints **the commits on the pull request branch**. Those commits are not what lands on `develop`.

This repo squash-merges, and `squash_merge_commit_title` is `COMMIT_OR_PR_TITLE`. GitHub composes the subject as:

- the **pull request title**, when the branch has more than one commit;
- the **head commit's own subject**, when the branch has exactly one;

then appends `` (#N) ``. Nothing lints that composed string. The branch commits pass, the pull request merges, and the release pull request is the first place the real subject is ever checked — by which point it is immutable history.

Both halves are observable in this repo. These four all had exactly one commit, and in every case what landed is the commit subject, not the title:

| PR | Title | Landed on `develop` |
|---|---|---|
| #543 | `fix: Quick Fix colors for Offline Panel` | `chore: delete wrong color (#543)` |
| #629 | `build: fix workflow issues` | ``build: remove `xcodes` installation (#629)`` |
| #588 | `fix: [FC-0078] fetch future course dates for calendar` | `fix: fetch future course dates for calendar (#588)` |
| #537 | `fix: The latest facebook sdk issue` | `fix: decrease facebook sdk version and fix open(url) calling (#537)` |

## What this does

A new workflow composes the same string GitHub will create — branching on the commit count exactly as `COMMIT_OR_PR_TITLE` does — and lints it with the **same `commitlint.config.mjs`**, so one ruleset governs the commits and the subject alike, and the two cannot drift apart.

Verified end to end in a clean checkout with no ancestor `node_modules`:

| Commits | Title | Subject that would land | Exit |
|---|---|---|---|
| 1 | `fix: correct course view padding` | `Update CourseView.swift (#700)` | **1** |
| 3 | `fix: correct course view padding` | `fix: correct course view padding (#700)` | 0 |
| 3 | `Fix/some thing` | `Fix/some thing (#700)` | **1** |
| 3 | `ci: something` | `ci: something (#700)` | **1** |
| 3 | `Fix/issue 581` | `Fix/issue 581 (#635)` | 0 |
| 3 | `Fix/issue 581` | `Fix/issue 581 (#700)` | **1** |

The first row is the case a title-only check reports green on. The last two show #667's grandfather list staying pinned to its exact commits: the same text at a new pull request number is rejected.

## Three details that are load-bearing

**Composing the `` (#N) `` suffix, not linting the bare title.** `header-max-length` is 110, and the config's own comment says it is set there "to account for PR numbers on squash merges". A 110-character title passes on its own and fails at 117 once the suffix is added. Linting the bare title would under-enforce the limit by the width of the suffix — which is how `Fixes:  Assignment thumbnails … (#649)` landed at 114.

**`npm install --no-save`, not `npx --package`.** commitlint resolves `extends` relative to the directory holding the config, so `@commitlint/config-conventional` has to sit beside `commitlint.config.mjs` at the repo root. Installing it through `npx --package` puts it in the npx cache, where the resolver cannot see it, and every run dies with `Cannot find module "@commitlint/config-conventional"` — failing closed on correct titles too. There is no root `package.json`, and `--no-save` writes neither one nor a lockfile, so only `node_modules` is left behind. Versions are pinned to 19.x to match the major that `wagoid/commitlint-github-action@v6.2.1` runs.

**`fetch-depth: 2` with an explicit head SHA.** The default checkout for `pull_request` is the merge ref, whose own subject is `Merge <sha> into <sha>` — never the string we want. Depth 2 brings in both parents so the head commit is readable for the single-commit case.

## Deliberate exclusions

Release pull requests (`develop` → `main`) are skipped. They land as merge commits, whose subject is GitHub's auto-generated `Merge pull request #N from …`, which commitlint ignores by default — so the release title never becomes a linted subject and checking it would be pure friction.

The pull request title is untrusted input. It is passed through `env:` rather than interpolated into the script, and `printf` feeds it to stdin so a subject beginning with `-` arrives as data. Verified inert: `feat: x"; touch /tmp/PWNED; echo "` creates no file. `permissions:` is `contents: read` — the title comes from the event payload, so there is no API call.

`pull_request`, not `pull_request_target`: read-only token, no secrets, and a pull request that edits `commitlint.config.mjs` is validated against its own new config. It does execute the pull request's config JS, but the existing commitlint job already does exactly that, so this adds no new exposure.

## Residual gaps

This does not cover a subject that reaches `develop` without a squash merge — an admin merge, a merge-commit strategy, or a direct push. Those are governed by branch protection rather than by CI, so they are out of scope here.

`edited` is in the trigger list because a title can be changed at any point, including after every other check has gone green.
